### PR TITLE
Fix async timeout issue

### DIFF
--- a/packages/backfill/src/__tests__/audit.test.ts
+++ b/packages/backfill/src/__tests__/audit.test.ts
@@ -6,10 +6,6 @@ import { setupFixture } from "backfill-utils-test";
 import { findPathToBackfill } from "./helper";
 import { sideEffectWarningString, noSideEffectString } from "../audit";
 
-function outputAllStd({ stderr, stdout }: execa.ExecaReturnValue) {
-  return `${stdout}\n${stderr}`;
-}
-
 describe("Audit", () => {
   let pathToBackfill: string;
   let backfillOutput: execa.ExecaReturnValue | undefined;
@@ -37,7 +33,7 @@ describe("Audit", () => {
       "npm run compile"
     ]);
 
-    expect(outputAllStd(backfillOutput)).toMatch(noSideEffectString);
+    expect(backfillOutput.all).toMatch(noSideEffectString);
   });
 
   it("correctly warns about side-effects", async () => {
@@ -47,7 +43,7 @@ describe("Audit", () => {
       "npm run compile && npm run side-effect"
     ]);
 
-    expect(outputAllStd(backfillOutput)).toMatch(sideEffectWarningString);
-    expect(outputAllStd(backfillOutput)).toMatch("monorepo/packages/DONE");
+    expect(backfillOutput.all).toMatch(sideEffectWarningString);
+    expect(backfillOutput.all).toMatch("monorepo/packages/DONE");
   });
 });

--- a/packages/backfill/src/audit.ts
+++ b/packages/backfill/src/audit.ts
@@ -90,16 +90,22 @@ export const sideEffectCallToActionString =
 export const noSideEffectString =
   "[audit] All observed file changes were within the scope of the folder to be cached.";
 
-export function closeWatcher() {
+async function delay(time: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, time);
+  });
+}
+
+export async function closeWatcher() {
   // Wait for one second before closing, giving time for file changes to propagate
-  setTimeout(() => {
-    if (changedFilesOutsideScope.length > 0) {
-      logger.warn(sideEffectWarningString);
-      changedFilesOutsideScope.forEach(file => logger.warn(`- ${file}`));
-      logger.warn(sideEffectCallToActionString);
-    } else {
-      logger.info(noSideEffectString);
-    }
-    watcher.close();
-  }, 1000);
+  await delay(1000);
+
+  if (changedFilesOutsideScope.length > 0) {
+    logger.warn(sideEffectWarningString);
+    changedFilesOutsideScope.forEach(file => logger.warn(`- ${file}`));
+    logger.warn(sideEffectCallToActionString);
+  } else {
+    logger.info(noSideEffectString);
+  }
+  watcher.close();
 }

--- a/packages/backfill/src/index.ts
+++ b/packages/backfill/src/index.ts
@@ -153,7 +153,7 @@ export async function main(): Promise<void> {
     await backfill(config, cacheStorage, buildCommand, hasher);
 
     if (argv["audit"]) {
-      closeWatcher();
+      await closeWatcher();
     }
   } catch (err) {
     logger.error(err.message || err);

--- a/packages/logger/src/genericLogger.ts
+++ b/packages/logger/src/genericLogger.ts
@@ -51,7 +51,7 @@ export const logger: Logger = {
 
   verbose(...args: any[]) {
     if (logLevelNumber(logLevel) >= logLevelNumber("verbose")) {
-      logInternal("info", "\u25a1 ", ...args);
+      logInternal("info", "\u25a1", ...args);
     }
   },
 


### PR DESCRIPTION
Another attempt to fix #35 

The theory this time is that placing the `watcher.close()` function inside of a setTimeout was not very smart. In this attempt, I'm awaiting a delay and then closing the watcher once that's done.