### PR TITLE
Rename to avoid confusion and improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The default configuration object is:
   logFolder: "node_modules/.cache/backfill",
   name: "name-of-package",
   outputFolder: "lib",
-  outputPerformanceLogs: false,
+  producePerformanceLogs: false,
   packageRoot: "path/to/package",
   clearOutputFolder: false,
   logLevel: "info",
@@ -115,7 +115,7 @@ export type Config = {
   logFolder: string;
   name: string;
   outputFolder: string;
-  outputPerformanceLogs: boolean;
+  producePerformanceLogs: boolean;
   packageRoot: string;
   performanceReportName?: string;
   clearOutputFolder: boolean;
@@ -199,7 +199,7 @@ output a log file after each run with performance metrics. Each log file is
 formatted as a csv file, containing only one row. You can run
 `backfill --generate-performance-report` to combine all logs in the log folder
 into one file. You can turn performance logging by setting
-`outputPerformanceLogs: true` in `backfill.config.js`.
+`producePerformanceLogs: true` in `backfill.config.js`.
 
 ## Contributing
 

--- a/packages/backfill/src/__tests__/backfill.test.ts
+++ b/packages/backfill/src/__tests__/backfill.test.ts
@@ -42,7 +42,7 @@ describe("backfill", () => {
 
     // Execute
     await backfill(
-      { ...config, outputPerformanceLogs: false },
+      { ...config, producePerformanceLogs: false },
       cacheStorage,
       spiedBuildCommand,
       hasher
@@ -60,7 +60,7 @@ describe("backfill", () => {
 
     // Execute
     await backfill(
-      { ...config, outputPerformanceLogs: false },
+      { ...config, producePerformanceLogs: false },
       cacheStorage,
       buildCommand,
       hasher

--- a/packages/backfill/src/index.ts
+++ b/packages/backfill/src/index.ts
@@ -26,7 +26,7 @@ export async function backfill(
     outputFolder,
     name,
     logFolder,
-    outputPerformanceLogs
+    producePerformanceLogs
   } = config;
 
   logger.setName(name);
@@ -52,7 +52,7 @@ export async function backfill(
     }
   }
 
-  if (outputPerformanceLogs) {
+  if (producePerformanceLogs) {
     await logger.toFile(logFolder);
   }
 }

--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -38,10 +38,10 @@ describe("getEnvConfig()", () => {
   });
 
   it("sets the performance logging flag through ENV variable", async () => {
-    process.env["BACKFILL_OUTPUT_PERFORMANCE_LOGS"] = "true";
+    process.env["BACKFILL_PRODUCE_PERFORMANCE_LOGS"] = "true";
 
     const config = getEnvConfig();
-    expect(config).toStrictEqual({ outputPerformanceLogs: true });
+    expect(config).toStrictEqual({ producePerformanceLogs: true });
   });
 
   it("sets local cache folder through ENV variable", async () => {

--- a/packages/config/src/envConfig.ts
+++ b/packages/config/src/envConfig.ts
@@ -6,7 +6,7 @@ import { CacheStorageConfig } from "./index";
 
 export type ConfigEnv = {
   cacheStorageConfig?: CacheStorageConfig;
-  outputPerformanceLogs?: boolean;
+  producePerformanceLogs?: boolean;
   internalCacheFolder?: string;
   logFolder?: string;
   performanceReportName?: string;
@@ -20,9 +20,12 @@ export function getEnvConfig() {
     config["logFolder"] = logFolder;
   }
 
-  const outputPerformanceLogs = process.env["BACKFILL_OUTPUT_PERFORMANCE_LOGS"];
-  if (outputPerformanceLogs) {
-    config["outputPerformanceLogs"] = Boolean(outputPerformanceLogs === "true");
+  const producePerformanceLogs =
+    process.env["BACKFILL_PRODUCE_PERFORMANCE_LOGS"];
+  if (producePerformanceLogs) {
+    config["producePerformanceLogs"] = Boolean(
+      producePerformanceLogs === "true"
+    );
   }
 
   const internalCacheFolder = process.env["BACKFILL_LOCAL_CACHE_FOLDER"];

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -18,7 +18,7 @@ export type Config = {
   logFolder: string;
   name: string;
   outputFolder: string;
-  outputPerformanceLogs: boolean;
+  producePerformanceLogs: boolean;
   packageRoot: string;
   performanceReportName?: string;
   clearOutputFolder: boolean;
@@ -65,7 +65,7 @@ export function createDefaultConfig(fromPath: string = process.cwd()): Config {
     internalCacheFolder: defaultCacheFolder,
     logFolder: defaultCacheFolder,
     outputFolder,
-    outputPerformanceLogs: false,
+    producePerformanceLogs: false,
     clearOutputFolder: false,
     logLevel: "info",
     hashGlobs: ["**/*", "!**/node_modules/**", `!${outputFolder}/**`]

--- a/packages/hasher/src/hashOfPackage.ts
+++ b/packages/hasher/src/hashOfPackage.ts
@@ -66,8 +66,9 @@ export async function getPackageHash(
   const filesHash = await generateHashOfFiles(packageRoot);
   const dependenciesHash = hashStrings(resolvedDependencies);
 
-  logger.silly(`filesHash of ${name}: ${filesHash}`);
-  logger.silly(`dependenciesHash of ${name}: ${dependenciesHash}`);
+  logger.silly(name);
+  logger.silly(`  ${filesHash} (fileHash)`);
+  logger.silly(`  ${dependenciesHash} (dependenciesHash)`);
 
   const packageHash = {
     name,


### PR DESCRIPTION
* Change outputPerformanceLogs -> producePerformanceLogs
* Add better readability on hash logging