### PR TITLE
For Azure Blob, extract directly to packageRoot

### DIFF
--- a/packages/cache/src/CacheStorage.ts
+++ b/packages/cache/src/CacheStorage.ts
@@ -15,27 +15,11 @@ export abstract class CacheStorage implements ICacheStorage {
   ): Promise<Boolean> {
     logger.profile("cache:fetch");
 
-    const localCacheFolder = await this._fetch(hash);
-
-    if (!localCacheFolder) {
-      logger.setTime("fetchTime", "cache:fetch");
-      logger.setHit(false);
-      return false;
-    }
-
-    logger.profile("cache:fetch:copy-to-outputfolder");
-    await Promise.all(
-      outputFolderAsArray(outputFolder).map(async folder => {
-        await fs.mkdirp(folder);
-        await fs.copy(path.join(localCacheFolder, folder), folder);
-      })
-    );
-    logger.profile("cache:fetch:copy-to-outputfolder");
-
-    logger.setHit(true);
+    const result = await this._fetch(hash, outputFolder);
     logger.setTime("fetchTime", "cache:fetch");
 
-    return true;
+    logger.setHit(result);
+    return result;
   }
 
   public async put(
@@ -57,7 +41,10 @@ export abstract class CacheStorage implements ICacheStorage {
     logger.setTime("putTime", "cache:put");
   }
 
-  protected abstract async _fetch(hash: string): Promise<string | undefined>;
+  protected abstract async _fetch(
+    hash: string,
+    outputFolder: string | string[]
+  ): Promise<boolean>;
   protected abstract async _put(
     hash: string,
     outputFolder: string | string[]

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -30,10 +30,7 @@ export function getCacheStorageProvider(
       internalCacheFolder
     );
   } else if (cacheStorageConfig.provider === "azure-blob") {
-    cacheStorage = new AzureBlobCacheStorage(
-      cacheStorageConfig.options,
-      internalCacheFolder
-    );
+    cacheStorage = new AzureBlobCacheStorage(cacheStorageConfig.options);
   } else {
     cacheStorage = new LocalCacheStorage(internalCacheFolder);
   }


### PR DESCRIPTION
This saves up to 5-10 seconds for each cache hit, depending on the size of the package that got cached.