### PR TITLE
Don't throw if an outputFolder doesn't exists

### DIFF
--- a/packages/cache/src/LocalCacheStorage.ts
+++ b/packages/cache/src/LocalCacheStorage.ts
@@ -26,8 +26,14 @@ export class LocalCacheStorage extends CacheStorage {
 
     await Promise.all(
       outputFolderAsArray(outputFolder).map(async folder => {
+        const locationInCache = path.join(localCacheFolder, folder);
+
+        if (!fs.pathExistsSync(locationInCache)) {
+          return;
+        }
+
         await fs.mkdirp(folder);
-        await fs.copy(path.join(localCacheFolder, folder), folder);
+        await fs.copy(locationInCache, folder);
       })
     );
 

--- a/packages/cache/src/NpmCacheStorage.ts
+++ b/packages/cache/src/NpmCacheStorage.ts
@@ -68,11 +68,17 @@ export class NpmCacheStorage extends CacheStorage {
 
     await Promise.all(
       outputFolderAsArray(outputFolder).map(async folder => {
-        await fs.mkdirp(folder);
-        await fs.copy(
-          path.join(packageFolderInTemporaryFolder, folder),
+        const locationInCache = path.join(
+          packageFolderInTemporaryFolder,
           folder
         );
+
+        if (!fs.pathExistsSync(locationInCache)) {
+          return;
+        }
+
+        await fs.mkdirp(folder);
+        await fs.copy(path.join(locationInCache, folder), folder);
       })
     );
 

--- a/packages/cache/src/__tests__/LocalCacheStorage.test.ts
+++ b/packages/cache/src/__tests__/LocalCacheStorage.test.ts
@@ -180,7 +180,7 @@ describe("LocalCacheStorage", () => {
         hash: "811c319a73f988d9260fbf3f1d30f0f447c2a194",
         outputFolder: "lib",
         expectSuccess: false,
-        errorMessage: "backfill is trying to cache"
+        errorMessage: "Couldn't find a folder on disk to cache"
       });
     });
   });


### PR DESCRIPTION
Currently, if one of the outputFolders doesn't exist, backfill throws an error. With this PR, you can specify a wider range of outputFolders in the root of your repo, and then for each package, the outputFolders that exists will be cached.

Fixes #118 