### PR TITLE
Use forward slash in globs on all platforms

### DIFF
--- a/packages/hasher/src/index.ts
+++ b/packages/hasher/src/index.ts
@@ -1,5 +1,3 @@
-import * as path from "path";
-
 import { logger } from "backfill-logger";
 import { outputFolderAsArray } from "backfill-config";
 
@@ -105,8 +103,8 @@ export class Hasher implements IHasher {
   }
 
   public async hashOfOutput(): Promise<string> {
-    const outputFolderGlob = outputFolderAsArray(this.outputFolder).map(p =>
-      path.join(p, "**")
+    const outputFolderGlob = outputFolderAsArray(this.outputFolder).map(
+      p => `${p}/**`
     );
 
     return generateHashOfFiles(this.packageRoot, outputFolderGlob);


### PR DESCRIPTION
Using `path.join` returns paths with backward slashes on Windows causing `hashOfOutput` to return zero results.