### PR TITLE
Remove yarn prepare and introduce yarn build on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,10 @@ jobs:
         with:
           node_version: ${{ matrix.node_version }}
 
-      - name: yarn install, yarn build, yarn test
+      - name: yarn install, yarn build
         run: |
           yarn install
           yarn build
-          yarn test
+
+      - name: yarn test
+        run: yarn test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           node_version: ${{ matrix.node_version }}
 
-      - name: yarn install, yarn test
+      - name: yarn install, yarn build, yarn test
         run: |
           yarn install
+          yarn build
           yarn test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "packages/*"
   ],
   "scripts": {
-    "postinstall": "yarn update-project-references && lerna run --stream prepare",
+    "build": "lerna run --stream build",
+    "postinstall": "yarn update-project-references",
     "lerna": "lerna",
     "test": "lerna run test",
     "prettier": "prettier \"{.,**}/*.{tsx,ts,js,json,md,yaml}\" --write",

--- a/packages/backfill/package.json
+++ b/packages/backfill/package.json
@@ -15,7 +15,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "test": "jest",
     "watch": "tsc -b -w"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "test": "jest",
     "watch": "tsc -b -w"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "test": "jest",
     "watch": "tsc -b -w"
   },

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "test": "jest",
     "watch": "tsc -b -w"
   },

--- a/packages/logger-generic/package.json
+++ b/packages/logger-generic/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "watch": "tsc -b -w"
   },
   "dependencies": {

--- a/packages/logger-performance/package.json
+++ b/packages/logger-performance/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "watch": "tsc -b -w"
   },
   "dependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "watch": "tsc -b -w"
   },
   "dependencies": {

--- a/packages/sample-dependency/package.json
+++ b/packages/sample-dependency/package.json
@@ -6,8 +6,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "backfill -- yarn compile",
-    "compile": "tsc -b",
-    "prepare": "backfill -- yarn compile"
+    "compile": "tsc -b"
   },
   "devDependencies": {
     "backfill": "^2.0.7",

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "build": "backfill -- yarn compile",
     "compile": "tsc -b",
-    "generate-report": "backfill --generate-performance-report",
-    "prepare": "backfill -- yarn compile"
+    "generate-report": "backfill --generate-performance-report"
   },
   "dependencies": {
     "backfill-sample-dependency": "^2.0.7"

--- a/packages/utils-dotenv/package.json
+++ b/packages/utils-dotenv/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "watch": "tsc -b -w"
   },
   "dependencies": {

--- a/packages/utils-test/package.json
+++ b/packages/utils-test/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "build": "yarn compile",
     "compile": "tsc -b",
-    "prepare": "yarn compile",
     "watch": "tsc -b -w"
   },
   "dependencies": {


### PR DESCRIPTION
TypeScript 3.7 does not need pre-built .d.ts files to understand types across packages/projects.