### PR TITLE
add support for single files output with glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The default configuration object is:
 The `outputGlob` is a list of globs describing the files you want to cache.
 `outputGlob` should be expressed as a relative path from the root of each
 package. If you want to cache `package-a/lib`, for instance, you'd write
-`outputGlob: ["lib/**"]`. If you also want to cache the `pacakge/a/dist/bundles`
+`outputGlob: ["lib/**"]`. If you also want to cache the `pacakge-a/dist/bundles`
 folder, you'd write `outputGlob: ["lib/**", "dist/bundles/**"]`.
 
 The configuration type is:

--- a/README.md
+++ b/README.md
@@ -100,19 +100,18 @@ The default configuration object is:
   logLevel: "info",
   mode: "READ_WRITE",
   name: "[name-of-package]",
-  outputFolder: "lib",
+  outputGlob: ["lib"],
   packageRoot: "path/to/package",
   producePerformanceLogs: false,
   validateOutput: false
 }
 ```
 
-The `outputFolder` is the folder you want to cache. It can either be a string or
-an array of strings. `outputFolder` should be expressed as a relative path from
-the root of each package. If you want to cache `package-a/lib`, for instance,
-you'd write `outputFolder: "lib"`. If you also want to cache the
-`pacakge/a/dist/bundles` folder, you'd write
-`outputFolder: ["lib", "dist/bundles"]`.
+The `outputGlob` is a list of globs describing the files you want to cache.
+`outputGlob` should be expressed as a relative path from the root of each
+package. If you want to cache `package-a/lib`, for instance, you'd write
+`outputGlob: ["lib/**"]`. If you also want to cache the `pacakge/a/dist/bundles`
+folder, you'd write `outputGlob: ["lib/**", "dist/bundles/**"]`.
 
 The configuration type is:
 
@@ -126,7 +125,7 @@ export type Config = {
   logLevel: LogLevels;
   mode: "READ_ONLY" | "WRITE_ONLY" | "READ_WRITE" | "PASS";
   name: string;
-  outputFolder: string | string[];
+  outputGlob: string[];
   packageRoot: string;
   performanceReportName?: string;
   producePerformanceLogs: boolean;

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The default configuration object is:
   logLevel: "info",
   mode: "READ_WRITE",
   name: "[name-of-package]",
-  outputGlob: ["lib"],
+  outputGlob: ["lib/**"],
   packageRoot: "path/to/package",
   producePerformanceLogs: false,
   validateOutput: false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "2.0.7",
+  "version": "3.0.0-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/backfill/package.json
+++ b/packages/backfill/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "bin": {
     "backfill": "./bin/backfill.js"
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "anymatch": "^3.0.3",
-    "backfill-cache": "^3.0.0-alpha.0",
-    "backfill-config": "^3.0.0-alpha.0",
-    "backfill-hasher": "^3.0.0-alpha.0",
-    "backfill-logger": "^3.0.0-alpha.0",
-    "backfill-utils-dotenv": "^3.0.0-alpha.0",
+    "backfill-cache": "^3.0.0",
+    "backfill-config": "^3.0.0",
+    "backfill-hasher": "^3.0.0",
+    "backfill-logger": "^3.0.0",
+    "backfill-utils-dotenv": "^3.0.0",
     "chokidar": "^3.2.1",
     "execa": "^4.0.0",
     "fast-glob": "^3.0.4",
@@ -36,7 +36,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^13.1.8",
     "@types/yargs": "^15.0.1",
-    "backfill-utils-test": "^3.0.0-alpha.0",
+    "backfill-utils-test": "^3.0.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "find-up": "^4.0.0",
     "jest": "^24.0.12",

--- a/packages/backfill/package.json
+++ b/packages/backfill/package.json
@@ -27,6 +27,7 @@
     "backfill-utils-dotenv": "^3.0.0-alpha.0",
     "chokidar": "^3.2.1",
     "execa": "^4.0.0",
+    "fast-glob": "^3.0.4",
     "fs-extra": "^8.1.0",
     "yargs": "^15.0.2"
   },

--- a/packages/backfill/package.json
+++ b/packages/backfill/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "bin": {
     "backfill": "./bin/backfill.js"
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "anymatch": "^3.0.3",
-    "backfill-cache": "^3.0.0",
-    "backfill-config": "^3.0.0",
-    "backfill-hasher": "^3.0.0",
-    "backfill-logger": "^3.0.0",
-    "backfill-utils-dotenv": "^3.0.0",
+    "backfill-cache": "^3.0.0-alpha.0",
+    "backfill-config": "^3.0.0-alpha.0",
+    "backfill-hasher": "^3.0.0-alpha.0",
+    "backfill-logger": "^3.0.0-alpha.0",
+    "backfill-utils-dotenv": "^3.0.0-alpha.0",
     "chokidar": "^3.2.1",
     "execa": "^4.0.0",
     "fast-glob": "^3.0.4",
@@ -36,7 +36,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^13.1.8",
     "@types/yargs": "^15.0.1",
-    "backfill-utils-test": "^3.0.0",
+    "backfill-utils-test": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "find-up": "^4.0.0",
     "jest": "^24.0.12",

--- a/packages/backfill/package.json
+++ b/packages/backfill/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.7",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "bin": {
     "backfill": "./bin/backfill.js"
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "anymatch": "^3.0.3",
-    "backfill-cache": "^2.0.6",
-    "backfill-config": "^2.0.6",
-    "backfill-hasher": "^2.0.7",
-    "backfill-logger": "^2.0.6",
-    "backfill-utils-dotenv": "^2.0.5",
+    "backfill-cache": "^3.0.0-alpha.0",
+    "backfill-config": "^3.0.0-alpha.0",
+    "backfill-hasher": "^3.0.0-alpha.0",
+    "backfill-logger": "^3.0.0-alpha.0",
+    "backfill-utils-dotenv": "^3.0.0-alpha.0",
     "chokidar": "^3.2.1",
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",
@@ -35,7 +35,7 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^13.1.8",
     "@types/yargs": "^15.0.1",
-    "backfill-utils-test": "^2.0.6",
+    "backfill-utils-test": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "find-up": "^4.0.0",
     "jest": "^24.0.12",

--- a/packages/backfill/src/__tests__/backfill.test.ts
+++ b/packages/backfill/src/__tests__/backfill.test.ts
@@ -1,4 +1,4 @@
-import { anyString, spy, verify, resetCalls } from "ts-mockito";
+import { anyString, anything, spy, verify, resetCalls } from "ts-mockito";
 
 import { setupFixture } from "backfill-utils-test";
 import { getCacheStorageProvider } from "backfill-cache";
@@ -16,9 +16,9 @@ describe("backfill", () => {
     const config = createConfig();
     const {
       cacheStorageConfig,
-      clearOutputFolder,
+      clearOutput,
       internalCacheFolder,
-      outputFolder,
+      outputGlob,
       packageRoot
     } = config;
 
@@ -30,10 +30,10 @@ describe("backfill", () => {
     const buildCommandRaw = "npm run compile";
     const buildCommand = createBuildCommand(
       [buildCommandRaw],
-      clearOutputFolder,
-      outputFolder
+      clearOutput,
+      outputGlob
     );
-    const hasher = new Hasher({ packageRoot, outputFolder }, buildCommandRaw);
+    const hasher = new Hasher({ packageRoot, outputGlob }, buildCommandRaw);
 
     // Spy
     const spiedCacheStorage = spy(cacheStorage);
@@ -46,8 +46,8 @@ describe("backfill", () => {
     // Assert
     verify(spiedHasher.createPackageHash()).once();
     expect(spiedBuildCommand).toHaveBeenCalled();
-    verify(spiedCacheStorage.fetch(anyString(), anyString())).once();
-    verify(spiedCacheStorage.put(anyString(), anyString())).once();
+    verify(spiedCacheStorage.fetch(anyString())).once();
+    verify(spiedCacheStorage.put(anyString(), anything())).once();
 
     resetCalls(spiedHasher);
     resetCalls(spiedCacheStorage);
@@ -59,7 +59,7 @@ describe("backfill", () => {
     // Assert
     verify(spiedHasher.createPackageHash()).once();
     expect(spiedBuildCommand).not.toHaveBeenCalled();
-    verify(spiedCacheStorage.fetch(anyString(), anyString())).once();
+    verify(spiedCacheStorage.fetch(anyString())).once();
     verify(spiedCacheStorage.put(anyString(), anyString())).never();
   });
 });

--- a/packages/backfill/src/__tests__/cli.test.ts
+++ b/packages/backfill/src/__tests__/cli.test.ts
@@ -5,7 +5,7 @@ import { createBuildCommand } from "../commandRunner";
 
 describe("createBuildCommand", () => {
   it("runs a command successfully", async () => {
-    const buildCommand = createBuildCommand(["echo foo"], false, "");
+    const buildCommand = createBuildCommand(["echo foo"], false, [""]);
 
     const buildResult = await buildCommand();
 
@@ -15,13 +15,13 @@ describe("createBuildCommand", () => {
   });
 
   it("resolves if no command can be found", async () => {
-    const buildCommand = createBuildCommand([""], false, "");
+    const buildCommand = createBuildCommand([""], false, [""]);
 
     await expect(buildCommand()).rejects.toThrow("Command not provided");
   });
 
   it("prints the error command and throws if it fails", async () => {
-    const buildCommand = createBuildCommand(["somecommand"], false, "");
+    const buildCommand = createBuildCommand(["somecommand"], false, [""]);
 
     try {
       await buildCommand();
@@ -33,7 +33,7 @@ describe("createBuildCommand", () => {
 
   it("clears the output folder", async () => {
     await setupFixture("pre-built");
-    const buildCommand = createBuildCommand(["echo foo"], true, "lib");
+    const buildCommand = createBuildCommand(["echo foo"], true, ["lib/**"]);
 
     const index_js_ExistsBeforeBuild = await fs.pathExists("lib/index.js");
     await buildCommand();

--- a/packages/backfill/src/commandRunner.ts
+++ b/packages/backfill/src/commandRunner.ts
@@ -24,7 +24,7 @@ export function createBuildCommand(
 
     if (clearOutput) {
       const filesToClear = fg.sync(outputGlob);
-      await Promise.all(filesToClear.map(fs.remove));
+      await Promise.all(filesToClear.map(async file => await fs.remove(file)));
     }
 
     // Set up runner

--- a/packages/backfill/src/commandRunner.ts
+++ b/packages/backfill/src/commandRunner.ts
@@ -24,7 +24,7 @@ export function createBuildCommand(
 
     if (clearOutput) {
       const filesToClear = fg.sync(outputGlob);
-      filesToClear.forEach(file => fs.remove(file));
+      await Promise.all(filesToClear.map(fs.remove));
     }
 
     // Set up runner

--- a/packages/backfill/src/commandRunner.ts
+++ b/packages/backfill/src/commandRunner.ts
@@ -1,7 +1,7 @@
 import * as execa from "execa";
 import * as fs from "fs-extra";
+import * as fg from "fast-glob";
 import { logger } from "backfill-logger";
-import { outputFolderAsArray } from "backfill-config";
 
 export type ExecaReturns = execa.ExecaChildProcess;
 export type BuildCommand = () => Promise<ExecaReturns | void>;
@@ -12,8 +12,8 @@ export function getRawBuildCommand(): string {
 
 export function createBuildCommand(
   buildCommand: string[],
-  clearOutputFolder: boolean,
-  outputFolder: string | string[]
+  clearOutput: boolean,
+  outputGlob: string[]
 ): () => Promise<ExecaReturns | void> {
   return async (): Promise<ExecaReturns | void> => {
     const parsedBuildCommand = buildCommand.join(" ");
@@ -22,11 +22,9 @@ export function createBuildCommand(
       throw new Error("Command not provided");
     }
 
-    // Clear outputFolder to guarantee a deterministic cache
-    if (clearOutputFolder) {
-      await Promise.all(
-        outputFolderAsArray(outputFolder).map(folder => fs.remove(folder))
-      );
+    if (clearOutput) {
+      const filesToClear = fg.sync(outputGlob);
+      filesToClear.forEach(file => fs.remove(file));
     }
 
     // Set up runner

--- a/packages/backfill/src/index.ts
+++ b/packages/backfill/src/index.ts
@@ -1,4 +1,5 @@
 import * as yargs from "yargs";
+
 import { loadDotenv } from "backfill-utils-dotenv";
 import { getCacheStorageProvider, ICacheStorage } from "backfill-cache";
 import { logger, setLogLevel } from "backfill-logger";

--- a/packages/backfill/src/index.ts
+++ b/packages/backfill/src/index.ts
@@ -25,7 +25,7 @@ export async function backfill(
 ): Promise<void> {
   const {
     cacheStorageConfig,
-    outputFolder,
+    outputGlob,
     name,
     mode,
     logFolder,
@@ -38,8 +38,7 @@ export async function backfill(
   logger.setCacheProvider(cacheStorageConfig.provider);
 
   const createPackageHash = async () => await hasher.createPackageHash();
-  const fetch = async (hash: string) =>
-    await cacheStorage.fetch(hash, outputFolder);
+  const fetch = async (hash: string) => await cacheStorage.fetch(hash);
   const run = async () => {
     try {
       await buildCommand();
@@ -49,7 +48,7 @@ export async function backfill(
   };
   const put = async (hash: string) => {
     try {
-      await cacheStorage.put(hash, outputFolder);
+      await cacheStorage.put(hash, outputGlob);
     } catch (err) {
       logger.error(
         `Failed to persist the cache with the following error:\n\n${err}`
@@ -106,12 +105,12 @@ export async function main(): Promise<void> {
     const config = createConfig();
     const {
       cacheStorageConfig,
-      clearOutputFolder,
+      clearOutput,
       hashGlobs,
       internalCacheFolder,
       logFolder,
       logLevel,
-      outputFolder,
+      outputGlob,
       packageRoot
     } = config;
 
@@ -131,11 +130,7 @@ export async function main(): Promise<void> {
         type: "boolean"
       }).argv;
 
-    const buildCommand = createBuildCommand(
-      argv["_"],
-      clearOutputFolder,
-      outputFolder
-    );
+    const buildCommand = createBuildCommand(argv["_"], clearOutput, outputGlob);
 
     const cacheStorage = getCacheStorageProvider(
       cacheStorageConfig,
@@ -143,7 +138,7 @@ export async function main(): Promise<void> {
     );
 
     const hasher = new Hasher(
-      { packageRoot, outputFolder },
+      { packageRoot, outputGlob },
       getRawBuildCommand()
     );
 
@@ -152,7 +147,7 @@ export async function main(): Promise<void> {
         packageRoot,
         internalCacheFolder,
         logFolder,
-        outputFolder,
+        outputGlob,
         hashGlobs
       );
     }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@azure/storage-blob": "12.1.0",
-    "backfill-config": "^3.0.0",
-    "backfill-logger": "^3.0.0",
+    "backfill-config": "^3.0.0-alpha.0",
+    "backfill-logger": "^3.0.0-alpha.0",
     "execa": "^4.0.0",
     "fast-glob": "^3.0.4",
     "fs-extra": "^8.1.0",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
     "@types/tar": "^4.0.0",
-    "backfill-utils-test": "^3.0.0",
+    "backfill-utils-test": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@azure/storage-blob": "12.1.0",
-    "backfill-config": "^3.0.0-alpha.0",
-    "backfill-logger": "^3.0.0-alpha.0",
+    "backfill-config": "^3.0.0",
+    "backfill-logger": "^3.0.0",
     "execa": "^4.0.0",
     "fast-glob": "^3.0.4",
     "fs-extra": "^8.1.0",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
     "@types/tar": "^4.0.0",
-    "backfill-utils-test": "^3.0.0-alpha.0",
+    "backfill-utils-test": "^3.0.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.6",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@azure/storage-blob": "12.0.1",
-    "backfill-config": "^2.0.6",
-    "backfill-logger": "^2.0.6",
+    "backfill-config": "^3.0.0-alpha.0",
+    "backfill-logger": "^3.0.0-alpha.0",
     "execa": "^4.0.0",
     "fast-glob": "^3.0.4",
     "fs-extra": "^8.1.0",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
     "@types/tar": "^4.0.0",
-    "backfill-utils-test": "^2.0.6",
+    "backfill-utils-test": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -20,6 +20,7 @@
     "backfill-config": "^2.0.6",
     "backfill-logger": "^2.0.6",
     "execa": "^4.0.0",
+    "fast-glob": "^3.0.4",
     "fs-extra": "^8.1.0",
     "tar": "^6.0.1"
   },

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -1,10 +1,8 @@
 import { BlobServiceClient } from "@azure/storage-blob";
 import * as tar from "tar";
+import * as fg from "fast-glob";
 
-import {
-  AzureBlobCacheStorageOptions,
-  outputFolderAsArray
-} from "backfill-config";
+import { AzureBlobCacheStorageOptions } from "backfill-config";
 
 import { CacheStorage } from "./CacheStorage";
 
@@ -71,10 +69,7 @@ export class AzureBlobCacheStorage extends CacheStorage {
     }
   }
 
-  protected async _put(
-    hash: string,
-    outputFolder: string | string[]
-  ): Promise<void> {
+  protected async _put(hash: string, outputGlob: string[]): Promise<void> {
     const blobClient = createBlobClient(
       this.options.connectionString,
       this.options.container,
@@ -83,8 +78,8 @@ export class AzureBlobCacheStorage extends CacheStorage {
 
     const blockBlobClient = blobClient.getBlockBlobClient();
 
-    const outputFolders = outputFolderAsArray(outputFolder);
-    const tarStream = tar.create({ gzip: false }, outputFolders);
+    const filesToCopy = fg.sync(outputGlob);
+    const tarStream = tar.create({ gzip: false }, filesToCopy);
 
     await blockBlobClient.uploadStream(
       tarStream,

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -78,7 +78,7 @@ export class AzureBlobCacheStorage extends CacheStorage {
 
     const blockBlobClient = blobClient.getBlockBlobClient();
 
-    const filesToCopy = fg.sync(outputGlob);
+    const filesToCopy = await fg(outputGlob);
     const tarStream = tar.create({ gzip: false }, filesToCopy);
 
     await blockBlobClient.uploadStream(

--- a/packages/cache/src/LocalCacheStorage.ts
+++ b/packages/cache/src/LocalCacheStorage.ts
@@ -31,10 +31,16 @@ export class LocalCacheStorage extends CacheStorage {
     const localCacheFolder = this.getLocalCacheFolder(hash);
 
     const files = fg.sync(outputGlob);
-    files.forEach(file => {
-      const destinationFolder = path.join(localCacheFolder, path.dirname(file));
-      fs.mkdirpSync(destinationFolder);
-      fs.copySync(file, path.join(localCacheFolder, file));
-    });
+
+    await Promise.all(
+      files.map(async file => {
+        const destinationFolder = path.join(
+          localCacheFolder,
+          path.dirname(file)
+        );
+        await fs.mkdirp(destinationFolder);
+        await fs.copy(file, path.join(localCacheFolder, file));
+      })
+    );
   }
 }

--- a/packages/cache/src/LocalCacheStorage.ts
+++ b/packages/cache/src/LocalCacheStorage.ts
@@ -20,9 +20,11 @@ export class LocalCacheStorage extends CacheStorage {
       return false;
     }
 
-    fs.readdirSync(localCacheFolder).forEach(fileOrFolder => {
-      fs.copySync(path.join(localCacheFolder, fileOrFolder), fileOrFolder);
-    });
+    await Promise.all(
+      fs.readdirSync(localCacheFolder).map(async fileOrFolder => {
+        await fs.copy(path.join(localCacheFolder, fileOrFolder), fileOrFolder);
+      })
+    );
 
     return true;
   }

--- a/packages/cache/src/LocalCacheStorage.ts
+++ b/packages/cache/src/LocalCacheStorage.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs-extra";
 import * as path from "path";
-
-import { outputFolderAsArray } from "backfill-config";
+import * as fg from "fast-glob";
 
 import { CacheStorage } from "./CacheStorage";
 
@@ -14,45 +13,28 @@ export class LocalCacheStorage extends CacheStorage {
     return path.join(this.internalCacheFolder, hash);
   }
 
-  protected async _fetch(
-    hash: string,
-    outputFolder: string | string[]
-  ): Promise<boolean> {
+  protected async _fetch(hash: string): Promise<boolean> {
     const localCacheFolder = this.getLocalCacheFolder(hash);
 
     if (!fs.pathExistsSync(localCacheFolder)) {
       return false;
     }
 
-    await Promise.all(
-      outputFolderAsArray(outputFolder).map(async folder => {
-        const locationInCache = path.join(localCacheFolder, folder);
-
-        if (!fs.pathExistsSync(locationInCache)) {
-          return;
-        }
-
-        await fs.mkdirp(folder);
-        await fs.copy(locationInCache, folder);
-      })
-    );
+    fs.readdirSync(localCacheFolder).forEach(fileOrFolder => {
+      fs.copySync(path.join(localCacheFolder, fileOrFolder), fileOrFolder);
+    });
 
     return true;
   }
 
-  protected async _put(
-    hash: string,
-    outputFolder: string | string[]
-  ): Promise<void> {
+  protected async _put(hash: string, outputGlob: string[]): Promise<void> {
     const localCacheFolder = this.getLocalCacheFolder(hash);
 
-    await Promise.all(
-      outputFolderAsArray(outputFolder).map(async folder => {
-        const outputFolderInCache = path.join(localCacheFolder, folder);
-
-        await fs.mkdirp(outputFolderInCache);
-        await fs.copy(folder, outputFolderInCache);
-      })
-    );
+    const files = fg.sync(outputGlob);
+    files.forEach(file => {
+      const destinationFolder = path.join(localCacheFolder, path.dirname(file));
+      fs.mkdirpSync(destinationFolder);
+      fs.copySync(file, path.join(localCacheFolder, file));
+    });
   }
 }

--- a/packages/cache/src/LocalCacheStorage.ts
+++ b/packages/cache/src/LocalCacheStorage.ts
@@ -20,9 +20,14 @@ export class LocalCacheStorage extends CacheStorage {
       return false;
     }
 
+    const files = await fg(`**/*`, {
+      cwd: path.join(process.cwd(), localCacheFolder)
+    });
+
     await Promise.all(
-      fs.readdirSync(localCacheFolder).map(async fileOrFolder => {
-        await fs.copy(path.join(localCacheFolder, fileOrFolder), fileOrFolder);
+      files.map(async file => {
+        await fs.mkdirp(path.dirname(file));
+        await fs.copy(path.join(localCacheFolder, file), file);
       })
     );
 

--- a/packages/cache/src/NpmCacheStorage.ts
+++ b/packages/cache/src/NpmCacheStorage.ts
@@ -71,7 +71,7 @@ export class NpmCacheStorage extends CacheStorage {
     await Promise.all(
       files.map(async file => {
         await fs.mkdirp(path.dirname(file));
-        fs.copy(path.join(packageFolderInTemporaryFolder, file), file);
+        await fs.copy(path.join(packageFolderInTemporaryFolder, file), file);
       })
     );
 

--- a/packages/cache/src/NpmCacheStorage.ts
+++ b/packages/cache/src/NpmCacheStorage.ts
@@ -64,12 +64,14 @@ export class NpmCacheStorage extends CacheStorage {
       }
     }
 
-    fs.readdirSync(packageFolderInTemporaryFolder).forEach(fileOrFolder => {
-      fs.copySync(
-        path.join(packageFolderInTemporaryFolder, fileOrFolder),
-        fileOrFolder
-      );
-    });
+    await Promise.all(
+      fs.readdirSync(packageFolderInTemporaryFolder).map(async fileOrFolder => {
+        fs.copy(
+          path.join(packageFolderInTemporaryFolder, fileOrFolder),
+          fileOrFolder
+        );
+      })
+    );
 
     return true;
   }

--- a/packages/cache/src/NpmCacheStorage.ts
+++ b/packages/cache/src/NpmCacheStorage.ts
@@ -64,12 +64,14 @@ export class NpmCacheStorage extends CacheStorage {
       }
     }
 
+    const files = await fg(`**/*`, {
+      cwd: path.join(process.cwd(), packageFolderInTemporaryFolder)
+    });
+
     await Promise.all(
-      fs.readdirSync(packageFolderInTemporaryFolder).map(async fileOrFolder => {
-        fs.copy(
-          path.join(packageFolderInTemporaryFolder, fileOrFolder),
-          fileOrFolder
-        );
+      files.map(async file => {
+        await fs.mkdirp(path.dirname(file));
+        fs.copy(path.join(packageFolderInTemporaryFolder, file), file);
       })
     );
 
@@ -92,7 +94,7 @@ export class NpmCacheStorage extends CacheStorage {
       version: `0.0.0-${hash}`
     });
 
-    const files = fg.sync(outputGlob);
+    const files = await fg(outputGlob);
 
     await Promise.all(
       files.map(async file => {

--- a/packages/cache/src/NpmCacheStorage.ts
+++ b/packages/cache/src/NpmCacheStorage.ts
@@ -91,14 +91,17 @@ export class NpmCacheStorage extends CacheStorage {
     });
 
     const files = fg.sync(outputGlob);
-    files.forEach(file => {
-      const destinationFolder = path.join(
-        temporaryNpmOutputFolder,
-        path.dirname(file)
-      );
-      fs.mkdirpSync(destinationFolder);
-      fs.copySync(file, path.join(temporaryNpmOutputFolder, file));
-    });
+
+    await Promise.all(
+      files.map(async file => {
+        const destinationFolder = path.join(
+          temporaryNpmOutputFolder,
+          path.dirname(file)
+        );
+        await fs.mkdirp(destinationFolder);
+        await fs.copy(file, path.join(temporaryNpmOutputFolder, file));
+      })
+    );
 
     // Upload package
     try {

--- a/packages/cache/src/__tests__/LocalCacheStorage.test.ts
+++ b/packages/cache/src/__tests__/LocalCacheStorage.test.ts
@@ -181,5 +181,35 @@ describe("LocalCacheStorage", () => {
           "Couldn't find any file on disk matching the output glob (lib/**, dist/**)"
       });
     });
+
+    it("will persist file matching glob in root folder", async () => {
+      await putInCache({
+        fixtureName: "basic",
+        hash: "811c319a73f988d9260fbf3f1d30f0f447c2a194",
+        outputGlob: ["tsconfig.tsbuildinfo"],
+        filesToCache: ["tsconfig.tsbuildinfo"]
+      });
+    });
+
+    it("will not persist file excluded by a glob", async () => {
+      await putInCache({
+        fixtureName: "basic",
+        hash: "811c319a73f988d9260fbf3f1d30f0f447c2a194",
+        expectSuccess: false,
+        outputGlob: ["lib/**", "!lib/qwerty"],
+        filesToCache: ["lib/qwerty"],
+        errorMessage:
+          "Couldn't find any file on disk matching the output glob (lib/**, !lib/qwerty)"
+      });
+    });
+
+    it("will persist file when others are excluded in the same folder", async () => {
+      await putInCache({
+        fixtureName: "basic",
+        hash: "46df1a257dfbde62b1e284f6382b20a49506f029",
+        outputGlob: ["lib/**", "!lib/qwerty"],
+        filesToCache: ["lib/azerty"]
+      });
+    });
   });
 });

--- a/packages/cache/src/__tests__/LocalCacheStorage.test.ts
+++ b/packages/cache/src/__tests__/LocalCacheStorage.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 
 import { setupFixture } from "backfill-utils-test";
-import { CacheStorageConfig, outputFolderAsArray } from "backfill-config";
+import { CacheStorageConfig } from "backfill-config";
 import { getCacheStorageProvider } from "../index";
 
 const setupCacheStorage = async (fixtureName: string) => {
@@ -40,7 +40,8 @@ function expectPathExists(pathToCheck: string, expectSuccess: boolean) {
 type CacheHelper = {
   fixtureName: string;
   hash: string;
-  outputFolder: string | string[];
+  outputGlob?: string[];
+  filesToCache?: string[];
   expectSuccess?: boolean;
   errorMessage?: string;
 };
@@ -48,7 +49,6 @@ type CacheHelper = {
 async function fetchFromCache({
   fixtureName,
   hash,
-  outputFolder,
   expectSuccess = true
 }: CacheHelper) {
   const { cacheStorage, internalCacheFolder } = await setupCacheStorage(
@@ -58,29 +58,20 @@ async function fetchFromCache({
   const secretFile = "qwerty";
 
   if (expectSuccess) {
-    outputFolderAsArray(outputFolder).forEach(folder => {
-      createFileInFolder(
-        path.join(internalCacheFolder, hash, folder),
-        secretFile,
-        true
-      );
-    });
+    createFileInFolder(path.join(internalCacheFolder, hash), secretFile, true);
   }
 
-  const fetchResult = await cacheStorage.fetch(hash, outputFolder);
+  const fetchResult = await cacheStorage.fetch(hash);
   expect(fetchResult).toBe(expectSuccess);
 
-  outputFolderAsArray(outputFolder).forEach(folder => {
-    const pathToCheck = expectSuccess ? path.join(folder, secretFile) : folder;
-
-    expectPathExists(pathToCheck, expectSuccess);
-  });
+  expectPathExists(secretFile, expectSuccess);
 }
 
 async function putInCache({
   fixtureName,
   hash,
-  outputFolder,
+  outputGlob,
+  filesToCache,
   expectSuccess = true,
   errorMessage
 }: CacheHelper) {
@@ -88,25 +79,31 @@ async function putInCache({
     fixtureName
   );
 
-  const secretFile = "qwerty";
+  if (!outputGlob) {
+    throw new Error("outputGlob should be provided to the putInCache function");
+  }
 
-  if (expectSuccess) {
-    outputFolderAsArray(outputFolder).forEach(folder => {
-      createFileInFolder(folder, secretFile, false);
-    });
+  if (!filesToCache) {
+    throw new Error(
+      "filesToCache should be provided to the putInCache function"
+    );
   }
 
   if (expectSuccess) {
-    await cacheStorage.put(hash, outputFolder);
+    filesToCache.forEach(f => createFileInFolder(".", f, false));
+  }
+
+  if (expectSuccess) {
+    await cacheStorage.put(hash, outputGlob);
   } else {
-    await expect(cacheStorage.put(hash, outputFolder)).rejects.toThrow(
+    await expect(cacheStorage.put(hash, outputGlob)).rejects.toThrow(
       errorMessage
     );
   }
 
-  outputFolderAsArray(outputFolder).forEach(folder => {
+  filesToCache.forEach(f => {
     const pathToCheck = expectSuccess
-      ? path.join(internalCacheFolder, hash, folder, secretFile)
+      ? path.join(internalCacheFolder, hash, f)
       : internalCacheFolder;
 
     expectPathExists(pathToCheck, expectSuccess);
@@ -118,24 +115,21 @@ describe("LocalCacheStorage", () => {
     it("will fetch on cache hit", async () => {
       await fetchFromCache({
         fixtureName: "with-cache",
-        hash: "811c319a73f988d9260fbf3f1d30f0f447c2a194",
-        outputFolder: "lib"
+        hash: "811c319a73f988d9260fbf3f1d30f0f447c2a194"
       });
     });
 
     it("will fetch on cache hit (output folder: dist)", async () => {
       await fetchFromCache({
         fixtureName: "with-cache-dist",
-        hash: "46df1a257dfbde62b1e284f6382b20a49506f029",
-        outputFolder: "dist"
+        hash: "46df1a257dfbde62b1e284f6382b20a49506f029"
       });
     });
 
     it("will fetch on cache hit (multiple output folders: lib and dist)", async () => {
       await fetchFromCache({
         fixtureName: "multiple-output-folders-with-cache",
-        hash: "46df1a257dfbde62b1e284f6382b20a49506f029",
-        outputFolder: ["lib", "dist"]
+        hash: "46df1a257dfbde62b1e284f6382b20a49506f029"
       });
     });
 
@@ -143,7 +137,6 @@ describe("LocalCacheStorage", () => {
       await fetchFromCache({
         fixtureName: "with-cache",
         hash: "incorrect_hash",
-        outputFolder: "lib",
         expectSuccess: false
       });
     });
@@ -154,7 +147,8 @@ describe("LocalCacheStorage", () => {
       await putInCache({
         fixtureName: "pre-built",
         hash: "811c319a73f988d9260fbf3f1d30f0f447c2a194",
-        outputFolder: "lib"
+        outputGlob: ["lib/**"],
+        filesToCache: ["lib/qwerty"]
       });
     });
 
@@ -162,7 +156,8 @@ describe("LocalCacheStorage", () => {
       await putInCache({
         fixtureName: "pre-built-dist",
         hash: "46df1a257dfbde62b1e284f6382b20a49506f029",
-        outputFolder: "dist"
+        outputGlob: ["dist/**"],
+        filesToCache: ["dist/qwerty"]
       });
     });
 
@@ -170,7 +165,8 @@ describe("LocalCacheStorage", () => {
       await putInCache({
         fixtureName: "multiple-output-folders",
         hash: "46df1a257dfbde62b1e284f6382b20a49506f029",
-        outputFolder: ["lib", "dist"]
+        outputGlob: ["lib/**", "dist/**"],
+        filesToCache: ["lib/qwerty", "dist/azer/ty"]
       });
     });
 
@@ -178,9 +174,11 @@ describe("LocalCacheStorage", () => {
       await putInCache({
         fixtureName: "basic",
         hash: "811c319a73f988d9260fbf3f1d30f0f447c2a194",
-        outputFolder: "lib",
         expectSuccess: false,
-        errorMessage: "Couldn't find a folder on disk to cache"
+        outputGlob: ["lib/**", "dist/**"],
+        filesToCache: [],
+        errorMessage:
+          "Couldn't find any file on disk matching the output glob (lib/**, dist/**)"
       });
     });
   });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -16,14 +16,14 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^3.0.0-alpha.0",
+    "backfill-generic-logger": "^3.0.0",
     "find-up": "^4.0.0",
     "fs-extra": "^8.1.0",
     "pkg-dir": "^4.2.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
-    "backfill-utils-test": "^3.0.0-alpha.0",
+    "backfill-utils-test": "^3.0.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.6",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -16,14 +16,14 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^2.0.6",
+    "backfill-generic-logger": "^3.0.0-alpha.0",
     "find-up": "^4.0.0",
     "fs-extra": "^8.1.0",
     "pkg-dir": "^4.2.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
-    "backfill-utils-test": "^2.0.6",
+    "backfill-utils-test": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -16,14 +16,14 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^3.0.0",
+    "backfill-generic-logger": "^3.0.0-alpha.0",
     "find-up": "^4.0.0",
     "fs-extra": "^8.1.0",
     "pkg-dir": "^4.2.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
-    "backfill-utils-test": "^3.0.0",
+    "backfill-utils-test": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -23,27 +23,19 @@ export type BackfillModes = keyof typeof modesObject;
 
 export type Config = {
   cacheStorageConfig: CacheStorageConfig;
-  clearOutputFolder: boolean;
+  clearOutput: boolean;
   hashGlobs: HashGlobs;
   internalCacheFolder: string;
   logFolder: string;
   logLevel: LogLevels;
   name: string;
   mode: BackfillModes;
-  outputFolder: string | string[];
+  outputGlob: string[];
   packageRoot: string;
   performanceReportName?: string;
   producePerformanceLogs: boolean;
   validateOutput: boolean;
 };
-
-export function outputFolderAsArray(outputFolder: string | string[]): string[] {
-  const outputFolders = Array.isArray(outputFolder)
-    ? outputFolder
-    : [outputFolder];
-
-  return outputFolders;
-}
 
 export function isCorrectMode(mode: string): mode is BackfillModes {
   return modesObject.hasOwnProperty(mode);
@@ -77,17 +69,17 @@ export function getSearchPaths(fromPath: string = process.cwd()) {
 export function createDefaultConfig(fromPath: string = process.cwd()): Config {
   const packageRoot = pkgDir.sync(fromPath) || fromPath;
   const defaultCacheFolder = path.join("node_modules", ".cache", "backfill");
-  const outputFolder = "lib";
+  const outputGlob = ["lib/**"];
 
   return {
     cacheStorageConfig: {
       provider: "local"
     },
-    clearOutputFolder: false,
+    clearOutput: false,
     hashGlobs: [
       "**/*",
       "!**/node_modules/**",
-      `!${outputFolder}/**`,
+      `!lib/**`,
       "!**/tsconfig.tsbuildinfo"
     ],
     internalCacheFolder: defaultCacheFolder,
@@ -95,7 +87,7 @@ export function createDefaultConfig(fromPath: string = process.cwd()): Config {
     logLevel: "info",
     name: getName(packageRoot),
     mode: "READ_WRITE",
-    outputFolder,
+    outputGlob,
     packageRoot,
     producePerformanceLogs: false,
     validateOutput: false

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
-    "backfill-config": "^3.0.0-alpha.0",
-    "backfill-logger": "^3.0.0-alpha.0",
+    "backfill-config": "^3.0.0",
+    "backfill-logger": "^3.0.0",
     "fast-glob": "^3.0.4",
     "find-up": "^4.1.0",
     "find-yarn-workspace-root": "^1.2.1",
@@ -29,7 +29,7 @@
     "@types/fs-extra": "^8.0.0",
     "@types/normalize-path": "^3.0.0",
     "@types/yarnpkg__lockfile": "^1.1.3",
-    "backfill-utils-test": "^3.0.0-alpha.0",
+    "backfill-utils-test": "^3.0.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
-    "backfill-config": "^3.0.0",
-    "backfill-logger": "^3.0.0",
+    "backfill-config": "^3.0.0-alpha.0",
+    "backfill-logger": "^3.0.0-alpha.0",
     "fast-glob": "^3.0.4",
     "find-up": "^4.1.0",
     "find-yarn-workspace-root": "^1.2.1",
@@ -29,7 +29,7 @@
     "@types/fs-extra": "^8.0.0",
     "@types/normalize-path": "^3.0.0",
     "@types/yarnpkg__lockfile": "^1.1.3",
-    "backfill-utils-test": "^3.0.0",
+    "backfill-utils-test": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.7",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
-    "backfill-config": "^2.0.6",
-    "backfill-logger": "^2.0.6",
+    "backfill-config": "^3.0.0-alpha.0",
+    "backfill-logger": "^3.0.0-alpha.0",
     "fast-glob": "^3.0.4",
     "find-up": "^4.1.0",
     "find-yarn-workspace-root": "^1.2.1",
@@ -29,7 +29,7 @@
     "@types/fs-extra": "^8.0.0",
     "@types/normalize-path": "^3.0.0",
     "@types/yarnpkg__lockfile": "^1.1.3",
-    "backfill-utils-test": "^2.0.6",
+    "backfill-utils-test": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "jest": "^24.0.12",
     "ts-jest": "^25.1.0",

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -19,6 +19,7 @@
     "@yarnpkg/lockfile": "^1.1.0",
     "backfill-config": "^3.0.0-alpha.0",
     "backfill-logger": "^3.0.0-alpha.0",
+    "fast-glob": "^3.0.4",
     "find-up": "^4.1.0",
     "find-yarn-workspace-root": "^1.2.1",
     "fs-extra": "^8.1.0",

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -19,7 +19,6 @@
     "@yarnpkg/lockfile": "^1.1.0",
     "backfill-config": "^3.0.0-alpha.0",
     "backfill-logger": "^3.0.0-alpha.0",
-    "fast-glob": "^3.0.4",
     "find-up": "^4.1.0",
     "find-yarn-workspace-root": "^1.2.1",
     "fs-extra": "^8.1.0",

--- a/packages/hasher/src/__tests__/index.test.ts
+++ b/packages/hasher/src/__tests__/index.test.ts
@@ -94,7 +94,7 @@ describe("The main Hasher class", () => {
   const setupFixtureAndReturnHash = async (fixture: string = "monorepo") => {
     const packageRoot = await setupFixture(fixture);
 
-    const options = { packageRoot, outputFolder: "lib" };
+    const options = { packageRoot, outputGlob: ["lib/**"] };
     const buildSignature = "yarn build";
 
     const hasher = new Hasher(options, buildSignature);

--- a/packages/hasher/src/index.ts
+++ b/packages/hasher/src/index.ts
@@ -1,5 +1,4 @@
 import { logger } from "backfill-logger";
-import { outputFolderAsArray } from "backfill-config";
 
 import { generateHashOfFiles } from "./hashOfFiles";
 import {
@@ -47,14 +46,14 @@ export function addToQueue(
 
 export class Hasher implements IHasher {
   private packageRoot: string;
-  private outputFolder: string | string[];
+  private outputGlob: string[];
 
   constructor(
-    private options: { packageRoot: string; outputFolder: string | string[] },
+    private options: { packageRoot: string; outputGlob: string[] },
     private buildCommandSignature: string
   ) {
     this.packageRoot = this.options.packageRoot;
-    this.outputFolder = this.options.outputFolder;
+    this.outputGlob = this.options.outputGlob;
   }
 
   public async createPackageHash(): Promise<string> {
@@ -103,10 +102,6 @@ export class Hasher implements IHasher {
   }
 
   public async hashOfOutput(): Promise<string> {
-    const outputFolderGlob = outputFolderAsArray(this.outputFolder).map(
-      p => `${p}/**`
-    );
-
-    return generateHashOfFiles(this.packageRoot, outputFolderGlob);
+    return generateHashOfFiles(this.packageRoot, this.outputGlob);
   }
 }

--- a/packages/logger-generic/package.json
+++ b/packages/logger-generic/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.6",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",

--- a/packages/logger-generic/package.json
+++ b/packages/logger-generic/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",

--- a/packages/logger-generic/package.json
+++ b/packages/logger-generic/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",

--- a/packages/logger-performance/package.json
+++ b/packages/logger-performance/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.6",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,13 +15,13 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^2.0.6",
+    "backfill-generic-logger": "^3.0.0-alpha.0",
     "filenamify": "^4.1.0",
     "fs-extra": "^8.1.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
-    "backfill-config": "^2.0.6",
+    "backfill-config": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/logger-performance/package.json
+++ b/packages/logger-performance/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,13 +15,13 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^3.0.0-alpha.0",
+    "backfill-generic-logger": "^3.0.0",
     "filenamify": "^4.1.0",
     "fs-extra": "^8.1.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
-    "backfill-config": "^3.0.0-alpha.0",
+    "backfill-config": "^3.0.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/logger-performance/package.json
+++ b/packages/logger-performance/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,13 +15,13 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^3.0.0",
+    "backfill-generic-logger": "^3.0.0-alpha.0",
     "filenamify": "^4.1.0",
     "fs-extra": "^8.1.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
-    "backfill-config": "^3.0.0",
+    "backfill-config": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.6",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,8 +15,8 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^2.0.6",
-    "backfill-performance-logger": "^2.0.6"
+    "backfill-generic-logger": "^3.0.0-alpha.0",
+    "backfill-performance-logger": "^3.0.0-alpha.0"
   },
   "devDependencies": {
     "backfill-utils-tsconfig": "^2.0.3",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,8 +15,8 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^3.0.0",
-    "backfill-performance-logger": "^3.0.0"
+    "backfill-generic-logger": "^3.0.0-alpha.0",
+    "backfill-performance-logger": "^3.0.0-alpha.0"
   },
   "devDependencies": {
     "backfill-utils-tsconfig": "^2.0.3",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,8 +15,8 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^3.0.0-alpha.0",
-    "backfill-performance-logger": "^3.0.0-alpha.0"
+    "backfill-generic-logger": "^3.0.0",
+    "backfill-performance-logger": "^3.0.0"
   },
   "devDependencies": {
     "backfill-utils-tsconfig": "^2.0.3",

--- a/packages/sample-dependency/package.json
+++ b/packages/sample-dependency/package.json
@@ -2,14 +2,14 @@
   "private": true,
   "name": "backfill-sample-dependency",
   "license": "MIT",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "backfill -- yarn compile",
     "compile": "tsc -b"
   },
   "devDependencies": {
-    "backfill": "^3.0.0",
+    "backfill": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/sample-dependency/package.json
+++ b/packages/sample-dependency/package.json
@@ -2,14 +2,14 @@
   "private": true,
   "name": "backfill-sample-dependency",
   "license": "MIT",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "backfill -- yarn compile",
     "compile": "tsc -b"
   },
   "devDependencies": {
-    "backfill": "^3.0.0-alpha.0",
+    "backfill": "^3.0.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/sample-dependency/package.json
+++ b/packages/sample-dependency/package.json
@@ -2,14 +2,14 @@
   "private": true,
   "name": "backfill-sample-dependency",
   "license": "MIT",
-  "version": "2.0.7",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "backfill -- yarn compile",
     "compile": "tsc -b"
   },
   "devDependencies": {
-    "backfill": "^2.0.7",
+    "backfill": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "backfill-sample",
   "license": "MIT",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "backfill -- yarn compile",
@@ -10,10 +10,10 @@
     "generate-report": "backfill --generate-performance-report"
   },
   "dependencies": {
-    "backfill-sample-dependency": "^3.0.0"
+    "backfill-sample-dependency": "^3.0.0-alpha.0"
   },
   "devDependencies": {
-    "backfill": "^3.0.0",
+    "backfill": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "backfill-sample",
   "license": "MIT",
-  "version": "2.0.7",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "backfill -- yarn compile",
@@ -10,10 +10,10 @@
     "generate-report": "backfill --generate-performance-report"
   },
   "dependencies": {
-    "backfill-sample-dependency": "^2.0.7"
+    "backfill-sample-dependency": "^3.0.0-alpha.0"
   },
   "devDependencies": {
-    "backfill": "^2.0.7",
+    "backfill": "^3.0.0-alpha.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "backfill-sample",
   "license": "MIT",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "backfill -- yarn compile",
@@ -10,10 +10,10 @@
     "generate-report": "backfill --generate-performance-report"
   },
   "dependencies": {
-    "backfill-sample-dependency": "^3.0.0-alpha.0"
+    "backfill-sample-dependency": "^3.0.0"
   },
   "devDependencies": {
-    "backfill": "^3.0.0-alpha.0",
+    "backfill": "^3.0.0",
     "backfill-utils-tsconfig": "^2.0.3",
     "typescript": "3.7.4"
   }

--- a/packages/utils-dotenv/package.json
+++ b/packages/utils-dotenv/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",

--- a/packages/utils-dotenv/package.json
+++ b/packages/utils-dotenv/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",

--- a/packages/utils-dotenv/package.json
+++ b/packages/utils-dotenv/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.5",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",

--- a/packages/utils-test/package.json
+++ b/packages/utils-test/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,7 +15,7 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^3.0.0",
+    "backfill-generic-logger": "^3.0.0-alpha.0",
     "find-up": "^4.0.0",
     "fs-extra": "^8.1.0",
     "tempy": "^0.3.0"

--- a/packages/utils-test/package.json
+++ b/packages/utils-test/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,7 +15,7 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^3.0.0-alpha.0",
+    "backfill-generic-logger": "^3.0.0",
     "find-up": "^4.0.0",
     "fs-extra": "^8.1.0",
     "tempy": "^0.3.0"

--- a/packages/utils-test/package.json
+++ b/packages/utils-test/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/backfill"
   },
-  "version": "2.0.6",
+  "version": "3.0.0-alpha.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "yarn compile",
@@ -15,7 +15,7 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "backfill-generic-logger": "^2.0.6",
+    "backfill-generic-logger": "^3.0.0-alpha.0",
     "find-up": "^4.0.0",
     "fs-extra": "^8.1.0",
     "tempy": "^0.3.0"


### PR DESCRIPTION
We can only cache files that are in a folder distinct from the root of the package and we cache everything within a folder.
 This PR introduces more flexibility where the cached files are defined with blobs instead of folders. We can now:
- have negative glob to exclude specific files. eg. ["lib/**", "!lib/tmp.json"] to cache the lib folder except tmp.json
- cache single files in any random folder, including the root of the package.