### PR TITLE
Print profile messages as verbose messages

### DIFF
--- a/packages/logger/src/consoleLogger.ts
+++ b/packages/logger/src/consoleLogger.ts
@@ -60,7 +60,7 @@ export function makeConsoleLogger(
 
     trace(...args: string[]): void {
       if (logFilter.shouldLog("verbose")) {
-        consoleOverride.error(...formatter.format("verbose", ...args));
+        consoleOverride.error(...formatter.format("trace", ...args));
       }
     }
   };

--- a/packages/logger/src/consoleLogger.ts
+++ b/packages/logger/src/consoleLogger.ts
@@ -60,7 +60,7 @@ export function makeConsoleLogger(
 
     trace(...args: string[]): void {
       if (logFilter.shouldLog("verbose")) {
-        consoleOverride.error(...formatter.format("trace", ...args));
+        consoleOverride.error(...formatter.format("verbose", ...args));
       }
     }
   };

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -99,7 +99,7 @@ export function makeLogger(
       return {
         stop: () => {
           const time = tracer.stop();
-          consoleLogger.trace(
+          consoleLogger.verbose(
             `Profiling ${chalk.underline(type)} took ${chalk.cyanBright(
               `${time} ms`
             )}`


### PR DESCRIPTION
Printing to console.trace will print to stderr. With this PR, we print profiling information through the verbose logger.