### PR TITLE
use globby instead of fast-glob

### DIFF
--- a/packages/backfill/package.json
+++ b/packages/backfill/package.json
@@ -27,7 +27,7 @@
     "backfill-utils-dotenv": "^4.1.2-alpha.0",
     "chokidar": "^3.2.1",
     "execa": "^4.0.0",
-    "fast-glob": "^3.0.4",
+    "globby": "^11.0.0",
     "fs-extra": "^8.1.0",
     "yargs": "^15.0.2"
   },

--- a/packages/backfill/src/commandRunner.ts
+++ b/packages/backfill/src/commandRunner.ts
@@ -1,6 +1,6 @@
 import execa from "execa";
 import fs from "fs-extra";
-import fg from "fast-glob";
+import globby from "globby";
 
 import { Logger } from "backfill-logger";
 
@@ -25,7 +25,7 @@ export function createBuildCommand(
     }
 
     if (clearOutput) {
-      const filesToClear = fg.sync(outputGlob);
+      const filesToClear = globby.sync(outputGlob);
       await Promise.all(filesToClear.map(async file => await fs.remove(file)));
     }
 

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -20,7 +20,7 @@
     "backfill-config": "^4.1.2-alpha.0",
     "backfill-logger": "^4.1.2-alpha.0",
     "execa": "^4.0.0",
-    "fast-glob": "^3.0.4",
+    "globby": "^11.0.0",
     "fs-extra": "^8.1.0",
     "tar": "^6.0.1"
   },

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -1,6 +1,6 @@
 import { BlobServiceClient } from "@azure/storage-blob";
 import tar from "tar";
-import fg from "fast-glob";
+import globby from "globby";
 
 import { Logger } from "backfill-logger";
 import { AzureBlobCacheStorageOptions } from "backfill-config";
@@ -83,7 +83,7 @@ export class AzureBlobCacheStorage extends CacheStorage {
 
     const blockBlobClient = blobClient.getBlockBlobClient();
 
-    const filesToCopy = await fg(outputGlob, { cwd: this.cwd });
+    const filesToCopy = await globby(outputGlob, { cwd: this.cwd });
     const tarStream = tar.create({ gzip: false, cwd: this.cwd }, filesToCopy);
 
     await blockBlobClient.uploadStream(

--- a/packages/cache/src/CacheStorage.ts
+++ b/packages/cache/src/CacheStorage.ts
@@ -1,4 +1,4 @@
-import fg from "fast-glob";
+import globby from "globby";
 
 import { Logger } from "backfill-logger";
 
@@ -23,7 +23,7 @@ export abstract class CacheStorage implements ICacheStorage {
   public async put(hash: string, outputGlob: string[]): Promise<void> {
     const tracer = this.logger.setTime("putTime");
 
-    const filesBeingCached = fg.sync(outputGlob, { cwd: this.cwd });
+    const filesBeingCached = globby.sync(outputGlob, { cwd: this.cwd });
     if (filesBeingCached.length === 0) {
       throw new Error(
         `Couldn't find any file on disk matching the output glob (${outputGlob.join(

--- a/packages/cache/src/LocalCacheStorage.ts
+++ b/packages/cache/src/LocalCacheStorage.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import fs from "fs-extra";
-import fg from "fast-glob";
+import globby from "globby";
 
 import { Logger } from "backfill-logger";
 
@@ -26,7 +26,7 @@ export class LocalCacheStorage extends CacheStorage {
       return false;
     }
 
-    const files = await fg(`**/*`, {
+    const files = await globby(`**/*`, {
       cwd: localCacheFolder
     });
 
@@ -46,7 +46,7 @@ export class LocalCacheStorage extends CacheStorage {
   protected async _put(hash: string, outputGlob: string[]): Promise<void> {
     const localCacheFolder = this.getLocalCacheFolder(hash);
 
-    const files = fg.sync(outputGlob, { cwd: this.cwd });
+    const files = globby.sync(outputGlob, { cwd: this.cwd });
 
     await Promise.all(
       files.map(async file => {

--- a/packages/cache/src/NpmCacheStorage.ts
+++ b/packages/cache/src/NpmCacheStorage.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import execa from "execa";
 import fs from "fs-extra";
-import fg from "fast-glob";
+import globby from "globby";
 
 import { NpmCacheStorageOptions } from "backfill-config";
 import { Logger } from "backfill-logger";
@@ -68,7 +68,7 @@ export class NpmCacheStorage extends CacheStorage {
       }
     }
 
-    const files = await fg(`**/*`, {
+    const files = await globby(`**/*`, {
       cwd: packageFolderInTemporaryFolder
     });
 
@@ -102,7 +102,7 @@ export class NpmCacheStorage extends CacheStorage {
       version: `0.0.0-${hash}`
     });
 
-    const files = await fg(outputGlob, { cwd: this.cwd });
+    const files = await globby(outputGlob, { cwd: this.cwd });
 
     await Promise.all(
       files.map(async file => {

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -22,7 +22,7 @@
     "@yarnpkg/lockfile": "^1.1.0",
     "backfill-config": "^4.1.2-alpha.0",
     "backfill-logger": "^4.1.2-alpha.0",
-    "fast-glob": "^3.0.4",
+    "globby": "^11.0.0",
     "find-up": "^4.1.0",
     "find-yarn-workspace-root": "^1.2.1",
     "fs-extra": "^8.1.0",

--- a/packages/hasher/src/hashOfFiles.ts
+++ b/packages/hasher/src/hashOfFiles.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import path from "path";
-import fg from "fast-glob";
+import globby from "globby";
 import fs from "fs-extra";
 
 import { hashStrings } from "./helpers";
@@ -8,15 +8,16 @@ import { hashStrings } from "./helpers";
 const newline = /\r\n|\r|\n/g;
 const LF = "\n";
 
+// We have to force the types because globby types are wrong
 export async function generateHashOfFiles(
   packageRoot: string,
   globs: string[]
 ): Promise<string> {
-  const files = await fg(globs, {
+  const files = ((await globby(globs, {
     cwd: packageRoot,
     onlyFiles: false,
     objectMode: true
-  });
+  })) as unknown) as { path: string; dirent: { isDirectory(): boolean } }[];
 
   files.sort((a, b) => a.path.localeCompare(b.path));
 

--- a/packages/hasher/src/workspaces/getPackagePaths.ts
+++ b/packages/hasher/src/workspaces/getPackagePaths.ts
@@ -1,12 +1,12 @@
 import path from "path";
-import fg from "fast-glob";
+import globby from "globby";
 
 export function getPackagePaths(
   workspacesRoot: string,
   packages: string[]
 ): string[] {
   const packagePaths = packages.map(glob =>
-    fg.sync(glob, {
+    globby.sync(glob, {
       cwd: workspacesRoot,
       onlyDirectories: true,
       absolute: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3611,7 +3611,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3, fast-glob@^3.0.4:
+fast-glob@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
   integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
@@ -3621,6 +3621,18 @@ fast-glob@^3.0.3, fast-glob@^3.0.4:
     glob-parent "^5.1.0"
     merge2 "^1.3.0"
     micromatch "^4.0.2"
+
+fast-glob@^3.1.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
+  integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -4125,6 +4137,18 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
+globby@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
+  integrity sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
@@ -4357,7 +4381,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1:
+ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -6855,6 +6879,11 @@ picomatch@^2.0.7:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
   integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
+
+picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
- Globby allows negative blobs
- It  is needed for a future PR but this change can be isolated to this
PR

Commands run to produce this change:
- `sed -i 's/import fg from "fast-glob"/import globby from "globby"/'
packages/*/src/**/*.ts`
- `sed -i 's/fast-glob": "^3.0.4"/globby": "^11.0.0"/'
packages/*/package.json`
- `sed -i 's/fg/globby/' packages/*/src/**/*.ts`
- manually override globby typings in hashOfFiles.ts
- yarn
- yarn build
- yarn test
