### PR TITLE
LocalSkipCacheStorage - a new cache storage driver that just skips rather than caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,20 +206,20 @@ BACKFILL_CACHE_PROVIDER_OPTIONS='{"npmPackageName":"...","registryUrl":"..."}'
 
 Sometimes in a local build environment, it is useful to compare hashes to
 determine whether to execute the task without having to explicitly use a
-separate directory for the cache. While running an incremental task, he
+separate directory for the cache. While running an incremental task, the
 generated build artifacts are the caches themselves.
 
-One caveat, this is using build outputs that the task produced and someone could
-possibly modify the **output** on a local development environment. For that
-reason, this cache mode is an opt-in rather than the default.
+One caveat, this is using output that the task produced and one could possibly
+modify the output on a local development environment. For this reason, this is
+an opt-in behavior rather than the default.
 
-The main benefit of using this strategy is speed. Backfill can skip file copying
-of the cached outputs if it can rely on the built artifacts. Hashing is
-CPU-bound while caching is I/O-bound. Using this strategy can result in
-signficant speed gains, but at the cost of needing to trust the outputs have not
-be altered by the user. From observation, this is usually true - but it is
-prudent to also provide a command in your repository to **clean** the output
-along with the saved hashes.
+The main benefit of using this strategy is a **significant** speed boost.
+Backfill can skip file copying of the cached outputs if it can rely on the built
+artifacts. Hashing is CPU-bound while caching is I/O-bound. Using this strategy
+results in speed gains but at the cost of needing to trust the outputs have not
+be altered by the user. While this usually is true, it is prudent to also
+provide a command in your repository to clean the output along with the saved
+hashes.
 
 You can configure this from the `backfill.config.js` file this way:
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,42 @@ BACKFILL_CACHE_PROVIDER="npm"
 BACKFILL_CACHE_PROVIDER_OPTIONS='{"npmPackageName":"...","registryUrl":"..."}'
 ```
 
+### Skipping cache locally
+
+Sometimes in a local build environment, it is useful to compare hashes to
+determine whether to execute the task without having to explicitly use a
+separate directory for the cache. While running an incremental task, he
+generated build artifacts are the caches themselves.
+
+One caveat, this is using build outputs that the task produced and someone could
+possibly modify the **output** on a local development environment. For that
+reason, this cache mode is an opt-in rather than the default.
+
+The main benefit of using this strategy is speed. Backfill can skip file copying
+of the cached outputs if it can rely on the built artifacts. Hashing is
+CPU-bound while caching is I/O-bound. Using this strategy can result in
+signficant speed gains, but at the cost of needing to trust the outputs have not
+be altered by the user. From observation, this is usually true - but it is
+prudent to also provide a command in your repository to **clean** the output
+along with the saved hashes.
+
+You can configure this from the `backfill.config.js` file this way:
+
+```js
+module.exports = {
+  cacheStorageConfig: {
+    provider: "local-skip"
+  }
+};
+```
+
+Like other cases, you can also use the environment variable to choose this
+storage strategy:
+
+```
+BACKFILL_CACHE_PROVIDER="local-skip"
+```
+
 ## API
 
 Backfill provides an API, this allows for more complex scenarios, and

--- a/README.md
+++ b/README.md
@@ -206,8 +206,7 @@ BACKFILL_CACHE_PROVIDER_OPTIONS='{"npmPackageName":"...","registryUrl":"..."}'
 
 Sometimes in a local build environment, it is useful to compare hashes to
 determine whether to execute the task without having to explicitly use a
-separate directory for the cache. While running an incremental task, the
-generated build artifacts are the caches themselves.
+separate directory for the cache.
 
 One caveat, this is using output that the task produced and one could possibly
 modify the output on a local development environment. For this reason, this is

--- a/packages/cache/src/LocalSkipCacheStorage.ts
+++ b/packages/cache/src/LocalSkipCacheStorage.ts
@@ -1,0 +1,39 @@
+import path from "path";
+import fs from "fs-extra";
+
+import { Logger } from "backfill-logger";
+
+import { CacheStorage } from "./CacheStorage";
+
+/**
+ * A CacheStorage that essentially just lets fetch return nothing locally, skipping cache, but verifies whether the hash is still correct based on the hasher algorithm
+ */
+export class LocalSkipCacheStorage extends CacheStorage {
+  constructor(
+    private internalCacheFolder: string,
+    logger: Logger,
+    cwd: string
+  ) {
+    super(logger, cwd);
+  }
+
+  protected getLocalCacheFolder(hash: string): string {
+    return path.resolve(this.cwd, this.internalCacheFolder, hash);
+  }
+
+  protected async _fetch(hash: string): Promise<boolean> {
+    const localCacheFolder = this.getLocalCacheFolder(hash);
+
+    if (!fs.pathExistsSync(localCacheFolder)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  protected async _put(hash: string, _outputGlob: string[]): Promise<void> {
+    const localCacheFolder = this.getLocalCacheFolder(hash);
+
+    await fs.mkdirp(localCacheFolder);
+  }
+}

--- a/packages/cache/src/LocalSkipCacheStorage.ts
+++ b/packages/cache/src/LocalSkipCacheStorage.ts
@@ -22,18 +22,21 @@ export class LocalSkipCacheStorage extends CacheStorage {
   }
 
   protected async _fetch(hash: string): Promise<boolean> {
-    const localCacheFolder = this.getLocalCacheFolder(hash);
+    const localCacheFolder = this.getLocalCacheFolder("skip-cache");
+    const hashFile = path.join(localCacheFolder, "hash");
 
-    if (!fs.pathExistsSync(localCacheFolder)) {
+    if (!fs.pathExistsSync(localCacheFolder) || !fs.existsSync(hashFile)) {
       return false;
     }
 
-    return true;
+    return hash === (await fs.readFile(hashFile, "utf-8"));
   }
 
   protected async _put(hash: string, _outputGlob: string[]): Promise<void> {
-    const localCacheFolder = this.getLocalCacheFolder(hash);
+    const localCacheFolder = this.getLocalCacheFolder("skip-cache");
+    const hashFile = path.join(localCacheFolder, "hash");
 
     await fs.mkdirp(localCacheFolder);
+    await fs.writeFile(hashFile, hash);
   }
 }

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -5,6 +5,7 @@ import { ICacheStorage } from "./CacheStorage";
 import { AzureBlobCacheStorage } from "./AzureBlobCacheStorage";
 import { LocalCacheStorage } from "./LocalCacheStorage";
 import { NpmCacheStorage } from "./NpmCacheStorage";
+import { LocalSkipCacheStorage } from "./LocalSkipCacheStorage";
 export { ICacheStorage } from "./CacheStorage";
 
 export function getCacheStorageProvider(
@@ -28,6 +29,8 @@ export function getCacheStorageProvider(
       logger,
       cwd
     );
+  } else if (cacheStorageConfig.provider === "local-skip") {
+    cacheStorage = new LocalSkipCacheStorage(internalCacheFolder, logger, cwd);
   } else {
     cacheStorage = new LocalCacheStorage(internalCacheFolder, logger, cwd);
   }

--- a/packages/config/src/cacheConfig.ts
+++ b/packages/config/src/cacheConfig.ts
@@ -25,6 +25,9 @@ export type CacheStorageConfig =
   | {
       provider: "local";
     }
+  | {
+      provider: "local-skip";
+    }
   | NpmCacheStorageConfig
   | AzureBlobCacheStorageConfig;
 


### PR DESCRIPTION
What this new cache storage does is NOTHING. It simply verifies that the local source hashes are equivalent and immediate returns. This is useful locally as it isn't always useful to have a separate local cache since the built artifacts are, in fact, the cache! The only caveat of this is that having built-artifact being the cache is potentially lossy since people directly work in those directories. However, it is a good assumption that people will likely not mess with their output MOST of the time. This is why it is an alternative local storage, but one that you can opt in when you know the devs in a repo can benefit from a dramatically increased speed in build skipping MOST of the time.

This driver STILL creates an empty directory as an output. We can discuss about whether to write a file rather than creating a directory - however, it seems pretty useful to just use the same internalCacheFolder itself to know whether the hash has changed or not. 