### PR TITLE
Max size option for Azure Blob provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,26 @@ module.exports = {
     options: {
       connectionString: "...",
       container: "..."
+      maxSize: 12345
     }
   }
 };
 ```
+
+#### Options
+
+<dl>
+  <dt>connectionString</dt>
+  <dd>retrieve this from the Azure Portal interface</dd>
+
+  <dt>container</dt>
+  <dd>the name of the blob storage container</dd>
+  
+  <dt>maxSize (<em>optional</em>)</dt>
+  <dd>
+    max size of a single package cache, in the number of bytes
+  </dd>
+</dl>
 
 You can also configure Microsoft Azure Blog Storage using environment variables.
 

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -51,12 +51,13 @@ export class AzureBlobCacheStorage extends CacheStorage {
       if (this.options.maxSize) {
         const sizeResponse = await blobClient.getProperties();
 
-        console.log(hash + " size " + sizeResponse.contentLength);
-
         if (
           sizeResponse.contentLength &&
           sizeResponse.contentLength > this.options.maxSize
         ) {
+          this.logger.verbose(
+            `A blob is too large to be downloaded: ${hash}, size: ${sizeResponse.contentLength} bytes`
+          );
           return false;
         }
       }
@@ -109,6 +110,9 @@ export class AzureBlobCacheStorage extends CacheStorage {
       }
 
       if (total > this.options.maxSize) {
+        this.logger.verbose(
+          `The output is too large to be uploaded: ${hash}, size: ${total} bytes`
+        );
         return;
       }
     }

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -5,6 +5,7 @@ import globby from "globby";
 import { Logger } from "backfill-logger";
 import { AzureBlobCacheStorageOptions } from "backfill-config";
 
+import { stat } from "fs-extra";
 import { CacheStorage } from "./CacheStorage";
 
 const ONE_MEGABYTE = 1024 * 1024;
@@ -46,6 +47,20 @@ export class AzureBlobCacheStorage extends CacheStorage {
         hash
       );
 
+      // If a maxSize has been specified, make sure to check the properties for the size before transferring
+      if (this.options.maxSize) {
+        const sizeResponse = await blobClient.getProperties();
+
+        console.log(hash + " size " + sizeResponse.contentLength);
+
+        if (
+          sizeResponse.contentLength &&
+          sizeResponse.contentLength > this.options.maxSize
+        ) {
+          return false;
+        }
+      }
+
       const response = await blobClient.download(0);
 
       const blobReadableStream = response.readableStreamBody;
@@ -85,6 +100,19 @@ export class AzureBlobCacheStorage extends CacheStorage {
 
     const filesToCopy = await globby(outputGlob, { cwd: this.cwd });
     const tarStream = tar.create({ gzip: false, cwd: this.cwd }, filesToCopy);
+
+    // If there's a maxSize limit, first sum up the total size of bytes of all the outputGlobbed files
+    if (this.options.maxSize) {
+      let total = 0;
+      for (const file of filesToCopy) {
+        total = total + (await stat(file)).size;
+      }
+
+      if (total > this.options.maxSize) {
+        console.log("too big to put! " + hash);
+        return;
+      }
+    }
 
     await blockBlobClient.uploadStream(
       tarStream,

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -109,7 +109,6 @@ export class AzureBlobCacheStorage extends CacheStorage {
       }
 
       if (total > this.options.maxSize) {
-        console.log("too big to put! " + hash);
         return;
       }
     }

--- a/packages/config/src/cacheConfig.ts
+++ b/packages/config/src/cacheConfig.ts
@@ -3,6 +3,7 @@ import { Logger } from "backfill-logger";
 export type AzureBlobCacheStorageOptions = {
   connectionString: string;
   container: string;
+  maxSize?: number;
 };
 
 export type NpmCacheStorageOptions = {
@@ -64,7 +65,11 @@ export function getAzureBlobConfigFromSerializedOptions(
 
     if (
       typeof parsedOptions.connectionString !== "string" ||
-      typeof parsedOptions.container !== "string"
+      typeof parsedOptions.container !== "string" ||
+      !(
+        typeof parsedOptions.maxSize === "undefined" ||
+        typeof parsedOptions.maxSize === "number"
+      )
     ) {
       throw new Error("Incorrect blob storage configuration");
     }


### PR DESCRIPTION
Fixes #244 - this adds an option to Azure Blob cache provider to allow to skip caching packages that have an output over a certain size. 