### PR TITLE
Fixes the put function for azure-blob if there is a maxSize option set.

### DIFF
--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import { BlobServiceClient } from "@azure/storage-blob";
 import tar from "tar";
 import globby from "globby";
@@ -106,7 +107,7 @@ export class AzureBlobCacheStorage extends CacheStorage {
     if (this.options.maxSize) {
       let total = 0;
       for (const file of filesToCopy) {
-        total = total + (await stat(file)).size;
+        total = total + (await stat(path.join(this.cwd, file))).size;
       }
 
       if (total > this.options.maxSize) {

--- a/packages/cache/src/LocalSkipCacheStorage.ts
+++ b/packages/cache/src/LocalSkipCacheStorage.ts
@@ -32,6 +32,7 @@ export class LocalSkipCacheStorage extends CacheStorage {
     return hash === (await fs.readFile(hashFile, "utf-8"));
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected async _put(hash: string, _outputGlob: string[]): Promise<void> {
     const localCacheFolder = this.getLocalCacheFolder("skip-cache");
     const hashFile = path.join(localCacheFolder, "hash");


### PR DESCRIPTION
fs.stat requires a full path in the usage of the backfill cache APIs