### PR TITLE
hash every git files

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ The default configuration object is:
 {
   cacheStorageConfig: { provider: "local" },
   clearOutputFolder: false,
-  hashGlobs: ["**/*", "!**/node_modules/**", "!lib/**", "!**/tsconfig.tsbuildinfo"],
   internalCacheFolder: "node_modules/.cache/backfill",
   logFolder: "node_modules/.cache/backfill",
   logLevel: "info",
@@ -120,7 +119,6 @@ The configuration type is:
 export type Config = {
   cacheStorageConfig: CacheStorageConfig;
   clearOutputFolder: boolean;
-  hashGlobs: HashGlobs;
   internalCacheFolder: string;
   logFolder: string;
   logLevel: LogLevels;

--- a/change/backfill-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
+++ b/change/backfill-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "no need to use globby for hash files",
+  "comment": "always use ** for hashGlob",
   "packageName": "backfill",
   "email": "vibailly@tuta.io",
   "dependentChangeType": "patch",

--- a/change/backfill-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
+++ b/change/backfill-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
@@ -1,0 +1,8 @@
+{
+  "type": "major",
+  "comment": "no need to use globby for hash files",
+  "packageName": "backfill",
+  "email": "vibailly@tuta.io",
+  "dependentChangeType": "patch",
+  "date": "2020-06-09T11:38:04.434Z"
+}

--- a/change/backfill-config-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
+++ b/change/backfill-config-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
@@ -1,0 +1,8 @@
+{
+  "type": "major",
+  "comment": "no need to use globby for hash files",
+  "packageName": "backfill-config",
+  "email": "vibailly@tuta.io",
+  "dependentChangeType": "patch",
+  "date": "2020-06-09T11:38:20.665Z"
+}

--- a/change/backfill-config-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
+++ b/change/backfill-config-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "no need to use globby for hash files",
+  "comment": "don't expose hashGlob anymore",
   "packageName": "backfill-config",
   "email": "vibailly@tuta.io",
   "dependentChangeType": "patch",

--- a/change/backfill-hasher-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
+++ b/change/backfill-hasher-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "no need to use globby for hash files",
+  "comment": "always use ** as hash glob",
   "packageName": "backfill-hasher",
   "email": "vibailly@tuta.io",
   "dependentChangeType": "patch",

--- a/change/backfill-hasher-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
+++ b/change/backfill-hasher-2020-06-09-13-38-25-vibailly-hash-every-git-files.json
@@ -1,0 +1,8 @@
+{
+  "type": "major",
+  "comment": "no need to use globby for hash files",
+  "packageName": "backfill-hasher",
+  "email": "vibailly@tuta.io",
+  "dependentChangeType": "patch",
+  "date": "2020-06-09T11:38:25.185Z"
+}

--- a/packages/backfill/src/__tests__/e2e.test.ts
+++ b/packages/backfill/src/__tests__/e2e.test.ts
@@ -24,7 +24,7 @@ describe("End to end", () => {
 
     // Verify it produces the correct hash
     const ownHash = fs.readdirSync(path.join(packageRoot, hashPath));
-    expect(ownHash).toContain("c83008b5a6698a7b96067e2b5325c99c9723f061");
+    expect(ownHash).toContain("dde4bee61d311ae4bedb5e9ada4b7a3cf6828da2");
 
     // ... and that `npm run compile` was run successfully
     const libFolderExist = await fs.pathExists(path.join(packageRoot, "lib"));

--- a/packages/backfill/src/__tests__/e2e.test.ts
+++ b/packages/backfill/src/__tests__/e2e.test.ts
@@ -24,7 +24,7 @@ describe("End to end", () => {
 
     // Verify it produces the correct hash
     const ownHash = fs.readdirSync(path.join(packageRoot, hashPath));
-    expect(ownHash).toContain("4de5081e0cf76c958c757519b9441a78a6c50f46");
+    expect(ownHash).toContain("c83008b5a6698a7b96067e2b5325c99c9723f061");
 
     // ... and that `npm run compile` was run successfully
     const libFolderExist = await fs.pathExists(path.join(packageRoot, "lib"));

--- a/packages/backfill/src/api.ts
+++ b/packages/backfill/src/api.ts
@@ -37,13 +37,13 @@ export async function computeHash(
   cwd: string,
   logger: Logger,
   hashSalt?: string,
-  config?: Pick<Config, "outputGlob" | "packageRoot" | "hashGlobs">
+  config?: Pick<Config, "packageRoot">
 ): Promise<string> {
   if (!config) {
     config = createConfig(logger, cwd);
   }
-  const { outputGlob, packageRoot, hashGlobs } = config;
-  const hasher = new Hasher({ packageRoot, outputGlob, hashGlobs }, logger);
+  const { packageRoot } = config;
+  const hasher = new Hasher({ packageRoot }, logger);
 
   const hash = await hasher.createPackageHash(hashSalt || "");
   return hash;
@@ -52,13 +52,13 @@ export async function computeHash(
 export async function computeHashOfOutput(
   cwd: string,
   logger: Logger,
-  config?: Pick<Config, "outputGlob" | "packageRoot" | "hashGlobs">
+  config?: Pick<Config, "packageRoot">
 ): Promise<string> {
   if (!config) {
     config = createConfig(logger, cwd);
   }
-  const { outputGlob, packageRoot, hashGlobs } = config;
-  const hasher = new Hasher({ packageRoot, outputGlob, hashGlobs }, logger);
+  const { packageRoot } = config;
+  const hasher = new Hasher({ packageRoot }, logger);
   const hash = await hasher.hashOfOutput();
   return hash;
 }

--- a/packages/backfill/src/audit.ts
+++ b/packages/backfill/src/audit.ts
@@ -36,7 +36,6 @@ export function initializeWatcher(
   internalCacheFolder: string,
   logFolder: string,
   outputGlob: string[],
-  hashGlobs: string[],
   logger: Logger
 ) {
   // Trying to find the git root and using it as an approximation of code boundary
@@ -58,7 +57,7 @@ export function initializeWatcher(
     internalCacheFolder
   ]);
   watcher = chokidar
-    .watch(hashGlobs, {
+    .watch("**", {
       ignored: ignoreGlobs,
       cwd: repositoryRoot,
       persistent: true,

--- a/packages/backfill/src/index.ts
+++ b/packages/backfill/src/index.ts
@@ -113,7 +113,6 @@ export async function main(): Promise<void> {
     const config = createConfig(logger, cwd);
     const {
       clearOutput,
-      hashGlobs,
       internalCacheFolder,
       logFolder,
       logLevel,
@@ -150,7 +149,6 @@ export async function main(): Promise<void> {
         internalCacheFolder,
         logFolder,
         outputGlob,
-        hashGlobs,
         logger
       );
     }

--- a/packages/cache/CHANGELOG.md
+++ b/packages/cache/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log - backfill-cache
 
-This log was last generated on Sat, 06 Jun 2020 19:22:26 GMT and should not be manually modified.
+This log was last generated on Sat, 06 Jun 2020 19:22:26 GMT and should not be
+manually modified.
 
 <!-- Start content -->
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -24,7 +24,6 @@ export type BackfillModes = keyof typeof modesObject;
 export type Config = {
   cacheStorageConfig: CacheStorageConfig;
   clearOutput: boolean;
-  hashGlobs: HashGlobs;
   internalCacheFolder: string;
   logFolder: string;
   logLevel: LogLevel;
@@ -81,12 +80,6 @@ export function createDefaultConfig(fromPath: string): Config {
       provider: "local"
     },
     clearOutput: false,
-    hashGlobs: [
-      "**/*",
-      "!**/node_modules/**",
-      `!lib/**`,
-      "!**/tsconfig.tsbuildinfo"
-    ],
     internalCacheFolder: defaultCacheFolder,
     logFolder: defaultCacheFolder,
     logLevel: "info",

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -21,7 +21,6 @@
     "backfill-logger": "^5.0.0",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",
-    "globby": "^11.0.0",
     "workspace-tools": "^0.7.6"
   },
   "devDependencies": {

--- a/packages/hasher/src/__tests__/hashOfFiles.test.ts
+++ b/packages/hasher/src/__tests__/hashOfFiles.test.ts
@@ -10,35 +10,12 @@ import { getRepoInfoNoCache } from "../repoInfo";
 describe("generateHashOfFiles()", () => {
   const logger = makeLogger("mute");
 
-  it("excludes files provided by backfill config", async () => {
-    const packageRoot = await setupFixture("monorepo");
-    let repoInfo = await getRepoInfoNoCache(packageRoot);
-
-    const hashOfEverything = await generateHashOfFiles(
-      packageRoot,
-      ["**"],
-      logger,
-      repoInfo
-    );
-
-    repoInfo = await getRepoInfoNoCache(packageRoot);
-    const hashExcludeNodeModules = await generateHashOfFiles(
-      packageRoot,
-      ["**", "!**/node_modules/**"],
-      logger,
-      repoInfo
-    );
-
-    expect(hashOfEverything).not.toEqual(hashExcludeNodeModules);
-  });
-
   it("creates different hashes for different hashes", async () => {
     const packageRoot = await setupFixture("monorepo");
     let repoInfo = await getRepoInfoNoCache(packageRoot);
 
     const hashOfPackage = await generateHashOfFiles(
       packageRoot,
-      ["**", "!**/node_modules/**"],
       logger,
       repoInfo
     );
@@ -48,7 +25,6 @@ describe("generateHashOfFiles()", () => {
 
     const hashOfPackageWithFoo = await generateHashOfFiles(
       packageRoot,
-      ["**", "!**/node_modules/**"],
       logger,
       repoInfo
     );
@@ -58,7 +34,6 @@ describe("generateHashOfFiles()", () => {
     repoInfo = await getRepoInfoNoCache(packageRoot);
     const hashOfPackageWithFoo2 = await generateHashOfFiles(
       packageRoot,
-      ["**", "!**/node_modules/**"],
       logger,
       repoInfo
     );
@@ -68,7 +43,6 @@ describe("generateHashOfFiles()", () => {
     repoInfo = await getRepoInfoNoCache(packageRoot);
     const hashOfPackageWithoutFoo = await generateHashOfFiles(
       packageRoot,
-      ["**", "!**/node_modules/**"],
       logger,
       repoInfo
     );

--- a/packages/hasher/src/__tests__/hashOfFiles.test.ts
+++ b/packages/hasher/src/__tests__/hashOfFiles.test.ts
@@ -3,29 +3,21 @@ import fs from "fs-extra";
 
 import { setupFixture } from "backfill-utils-test";
 
-import { makeLogger } from "backfill-logger";
 import { generateHashOfFiles } from "../hashOfFiles";
 import { getRepoInfoNoCache } from "../repoInfo";
 
 describe("generateHashOfFiles()", () => {
-  const logger = makeLogger("mute");
-
   it("creates different hashes for different hashes", async () => {
     const packageRoot = await setupFixture("monorepo");
     let repoInfo = await getRepoInfoNoCache(packageRoot);
 
-    const hashOfPackage = await generateHashOfFiles(
-      packageRoot,
-      logger,
-      repoInfo
-    );
+    const hashOfPackage = await generateHashOfFiles(packageRoot, repoInfo);
 
     fs.writeFileSync(path.join(packageRoot, "foo.txt"), "bar");
     repoInfo = await getRepoInfoNoCache(packageRoot);
 
     const hashOfPackageWithFoo = await generateHashOfFiles(
       packageRoot,
-      logger,
       repoInfo
     );
     expect(hashOfPackage).not.toEqual(hashOfPackageWithFoo);
@@ -34,7 +26,6 @@ describe("generateHashOfFiles()", () => {
     repoInfo = await getRepoInfoNoCache(packageRoot);
     const hashOfPackageWithFoo2 = await generateHashOfFiles(
       packageRoot,
-      logger,
       repoInfo
     );
     expect(hashOfPackageWithFoo).not.toEqual(hashOfPackageWithFoo2);
@@ -43,7 +34,6 @@ describe("generateHashOfFiles()", () => {
     repoInfo = await getRepoInfoNoCache(packageRoot);
     const hashOfPackageWithoutFoo = await generateHashOfFiles(
       packageRoot,
-      logger,
       repoInfo
     );
     expect(hashOfPackage).toEqual(hashOfPackageWithoutFoo);

--- a/packages/hasher/src/__tests__/index.test.ts
+++ b/packages/hasher/src/__tests__/index.test.ts
@@ -103,7 +103,7 @@ describe("The main Hasher class", () => {
   const setupFixtureAndReturnHash = async (fixture = "monorepo") => {
     const packageRoot = await setupFixture(fixture);
 
-    const options = { packageRoot, outputGlob: ["lib/**"], hashGlobs: ["**"] };
+    const options = { packageRoot, outputGlob: ["lib/**"] };
     const buildSignature = "yarn build";
 
     const hasher = new Hasher(options, logger);

--- a/packages/hasher/src/hashOfFiles.ts
+++ b/packages/hasher/src/hashOfFiles.ts
@@ -20,13 +20,12 @@ import { RepoInfo } from "./repoInfo";
  */
 export async function generateHashOfFiles(
   packageRoot: string,
-  globs: string[],
   logger: Logger,
   repoInfo: RepoInfo
 ): Promise<string> {
   const { repoHashes, root } = repoInfo;
 
-  const files = ((await globby(globs, {
+  const files = ((await globby("**", {
     cwd: packageRoot,
     onlyFiles: false,
     objectMode: true

--- a/packages/hasher/src/hashOfFiles.ts
+++ b/packages/hasher/src/hashOfFiles.ts
@@ -1,6 +1,5 @@
 import path from "path";
-import globby from "globby";
-import { Logger } from "backfill-logger";
+
 import { hashStrings } from "./helpers";
 import { RepoInfo } from "./repoInfo";
 
@@ -20,42 +19,20 @@ import { RepoInfo } from "./repoInfo";
  */
 export async function generateHashOfFiles(
   packageRoot: string,
-  logger: Logger,
   repoInfo: RepoInfo
 ): Promise<string> {
   const { repoHashes, root } = repoInfo;
 
-  const files = ((await globby("**", {
-    cwd: packageRoot,
-    onlyFiles: false,
-    objectMode: true
-  })) as unknown) as { path: string; dirent: { isDirectory(): boolean } }[];
+  const files: string[] = Object.keys(repoHashes).filter(f =>
+    path.join(root, f).includes(path.normalize(packageRoot))
+  );
 
-  files.sort((a, b) => a.path.localeCompare(b.path));
+  files.sort((a, b) => a.localeCompare(b));
 
   const hashes: string[] = [];
 
-  for (const entry of files) {
-    if (!entry.dirent.isDirectory()) {
-      // if the entry is a file, use the "git hash-object" hash (which is a sha1 of path + size, but super fast, and potentially already cached)
-      const normalized = (
-        path
-          .normalize(packageRoot)
-          .replace(path.normalize(root), "")
-          .replace(/\\/g, "/") +
-        "/" +
-        entry.path
-      ).slice(1);
-
-      if (!repoHashes[normalized]) {
-        logger.warn(`cannot find file "${normalized}"`);
-      } else {
-        hashes.push(repoHashes[normalized]);
-      }
-    } else {
-      // if the entry is a directory, just put the directory in the hashes
-      hashes.push(entry.path);
-    }
+  for (const file of files) {
+    hashes.push(repoHashes[file]);
   }
 
   return hashStrings(hashes);

--- a/packages/hasher/src/hashOfPackage.ts
+++ b/packages/hasher/src/hashOfPackage.ts
@@ -73,7 +73,7 @@ export async function getPackageHash(
     ...externalDeoendencies
   ];
 
-  const filesHash = await generateHashOfFiles(packageRoot, logger, repoInfo);
+  const filesHash = await generateHashOfFiles(packageRoot, repoInfo);
   const dependenciesHash = hashStrings(resolvedDependencies);
 
   logger.silly(name);

--- a/packages/hasher/src/hashOfPackage.ts
+++ b/packages/hasher/src/hashOfPackage.ts
@@ -37,8 +37,7 @@ const memoization: { [key: string]: PackageHashInfo } = {};
 export async function getPackageHash(
   packageRoot: string,
   repoInfo: RepoInfo,
-  logger: Logger,
-  hashGlobs: string[]
+  logger: Logger
 ): Promise<PackageHashInfo> {
   const { workspaceInfo, parsedLock } = repoInfo;
 
@@ -74,12 +73,7 @@ export async function getPackageHash(
     ...externalDeoendencies
   ];
 
-  const filesHash = await generateHashOfFiles(
-    packageRoot,
-    hashGlobs,
-    logger,
-    repoInfo
-  );
+  const filesHash = await generateHashOfFiles(packageRoot, logger, repoInfo);
   const dependenciesHash = hashStrings(resolvedDependencies);
 
   logger.silly(name);

--- a/packages/hasher/src/index.ts
+++ b/packages/hasher/src/index.ts
@@ -41,21 +41,15 @@ export function addToQueue(
 
 export class Hasher implements IHasher {
   private packageRoot: string;
-  private outputGlob: string[];
-  private hashGlobs: string[];
   private repoInfo?: RepoInfo;
 
   constructor(
     private options: {
       packageRoot: string;
-      outputGlob: string[];
-      hashGlobs: string[];
     },
     private logger: Logger
   ) {
     this.packageRoot = this.options.packageRoot;
-    this.outputGlob = this.options.outputGlob;
-    this.hashGlobs = this.options.hashGlobs;
   }
 
   public async createPackageHash(salt: string): Promise<string> {
@@ -80,8 +74,7 @@ export class Hasher implements IHasher {
       const packageHash = await getPackageHash(
         packageRoot,
         this.repoInfo,
-        this.logger,
-        this.hashGlobs
+        this.logger
       );
 
       addToQueue(packageHash.internalDependencies, queue, done, workspaceInfo);
@@ -111,12 +104,7 @@ export class Hasher implements IHasher {
   public async hashOfOutput(): Promise<string> {
     const repoInfo = await getRepoInfoNoCache(this.packageRoot);
 
-    return generateHashOfFiles(
-      this.packageRoot,
-      this.outputGlob,
-      this.logger,
-      repoInfo
-    );
+    return generateHashOfFiles(this.packageRoot, this.logger, repoInfo);
   }
 }
 

--- a/packages/hasher/src/index.ts
+++ b/packages/hasher/src/index.ts
@@ -104,7 +104,7 @@ export class Hasher implements IHasher {
   public async hashOfOutput(): Promise<string> {
     const repoInfo = await getRepoInfoNoCache(this.packageRoot);
 
-    return generateHashOfFiles(this.packageRoot, this.logger, repoInfo);
+    return generateHashOfFiles(this.packageRoot, repoInfo);
   }
 }
 


### PR DESCRIPTION
Describing the files to hash seems to be redundant with the gitignore. We have not been able to identify a scenario in which we would want to customize the hashGlob so we removed this option.

Also we don't need to use globby to query the hash files because they are already contained in the repo-info