### PR TITLE
Bump workspace tools

### DIFF
--- a/change/backfill-hasher-2020-07-17-12-17-25-bump-workspace-tools.json
+++ b/change/backfill-hasher-2020-07-17-12-17-25-bump-workspace-tools.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "bumping workspace-tools to allow accepting a PREFFERRED_WORKSPACE_MANAGER when multiple lock files implementations exist in one repo",
+  "packageName": "backfill-hasher",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-17T19:17:25.423Z"
+}

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -21,7 +21,7 @@
     "backfill-logger": "^5.0.0",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",
-    "workspace-tools": "^0.7.6"
+    "workspace-tools": "^0.9.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8706,10 +8706,10 @@ wordwrap@^1.0.0, wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-workspace-tools@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.7.6.tgz#4c3e9880d7f5afd6e650d9e58785f31389f68f74"
-  integrity sha512-iNGCMTr/fnZ7xWNDHro4B5Le7Tx8hywfxfjVZZSIsje5J3hjE76cxHdFRhd0VNJ1dMJ2Zqs3iOqg1scgIwCx+w==
+workspace-tools@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.9.0.tgz#5ce0680c9bf38544d1f6261d6b0e2834347e676e"
+  integrity sha512-ji9mOpdxyJ1LBnCzfFzAuLw7x0OuqQso/eJFpeyR/W0nXRK3Uhmn0dAaqrlDlrUEW5nOT5nSz0MpsaCmeSyiUA==
   dependencies:
     "@pnpm/lockfile-file" "^3.0.7"
     "@pnpm/logger" "^3.2.2"


### PR DESCRIPTION
This bumps WST to get a new functionality of adding the PREFERRED_WORKSPACE_MANAGER environment variable. This is useful when transitioning from one workspace manager to another when multiple workspace management lock file or config file are present.