### PR TITLE
Beachball - don't publish fixtures

### DIFF
--- a/change/empty-2020-08-18-14-52-43-bewegger-include-filepaths-in-hash.json
+++ b/change/empty-2020-08-18-14-52-43-bewegger-include-filepaths-in-hash.json
@@ -1,8 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Add empty fixture.",
-  "packageName": "empty",
-  "email": "bewegger@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-08-18T12:52:43.415Z"
-}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "lerna run --stream build",
-    "change": "beachball change",
+    "change": "beachball change --scope \"!packages/utils-test/__fixtures__/*\"",
     "checkchange": "beachball check",
     "postinstall": "yarn update-project-references",
     "lerna": "lerna",


### PR DESCRIPTION
Make beachball ignore packages in `packages/utils-test/__fixtures__`. Also, delete an incorrect change file for one of the fixture packages.