### PR TITLE
Update package-deps-hash

### DIFF
--- a/change/backfill-hasher-2020-08-31-16-32-54-bewegger-update-package-deps-hash.json
+++ b/change/backfill-hasher-2020-08-31-16-32-54-bewegger-update-package-deps-hash.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update package-deps-hash",
+  "packageName": "backfill-hasher",
+  "email": "bewegger@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-31T14:32:54.127Z"
+}

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -16,7 +16,7 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "@rushstack/package-deps-hash": "^2.4.22",
+    "@rushstack/package-deps-hash": "^2.4.48",
     "backfill-config": "^6.0.0",
     "backfill-logger": "^5.0.0",
     "find-up": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1576,25 +1576,27 @@
   resolved "https://registry.yarnpkg.com/@pnpm/types/-/types-5.0.0.tgz#522be0fc8cd3efed8df36e496f7e3edadad8d807"
   integrity sha512-atnG7xWrtf22WNXFHQCqK+/LJnCuUNsWxUTg2uhvSq6OlcdviPe67AveqDv/q9KGkpBrEcqg7ChlhJyRjNE9zg==
 
-"@rushstack/node-core-library@3.24.0":
-  version "3.24.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.24.0.tgz#8a22612a2dd3805049027427384c6f1a123a6610"
-  integrity sha512-0UnaRKwjprJ4LJkdp6fjuiRuKbtH8PqomKT3RiNPK0p1cEnSTs5vSQxw47bAKQVqERoV7im+rbryc4onYgLFcw==
+"@rushstack/node-core-library@3.30.0":
+  version "3.30.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.30.0.tgz#a2b814a611a040ac69d6c31ffc92bf9155c983fb"
+  integrity sha512-vZo1fi/ObL3CmRXlQUX/E1xL9KL9arBfCJ7pYf3O/vFrD8ffSfpQ6+6lhgAsKrCIM5Epddsgeb2REPxMwYZX1g==
   dependencies:
     "@types/node" "10.17.13"
     colors "~1.2.1"
     fs-extra "~7.0.1"
+    import-lazy "~4.0.0"
     jju "~1.4.0"
-    semver "~5.3.0"
+    resolve "~1.17.0"
+    semver "~7.3.0"
     timsort "~0.3.0"
     z-schema "~3.18.3"
 
-"@rushstack/package-deps-hash@^2.4.22":
-  version "2.4.22"
-  resolved "https://registry.yarnpkg.com/@rushstack/package-deps-hash/-/package-deps-hash-2.4.22.tgz#2fe7f52b9200990b1d8e7e7372f9cde996689b8c"
-  integrity sha512-13XtcE2sPhkhBM4nh/FSsVbcR6zAgIaODkqD0baI7JKtoK9fAtVghbvVNb9bR/eoG6Isttb7YC5JOzSHeDE4TA==
+"@rushstack/package-deps-hash@^2.4.48":
+  version "2.4.48"
+  resolved "https://registry.yarnpkg.com/@rushstack/package-deps-hash/-/package-deps-hash-2.4.48.tgz#14e4318535000e900345e7ee2a5e7f07326b7783"
+  integrity sha512-1myqAWqgOM9EdiJX5knauEhEhC+kaufIFDMEQyfduLaJKgSWIGEKnVcRvJX+v7MuhqbyBMlHFORxg3KPtLBBBg==
   dependencies:
-    "@rushstack/node-core-library" "3.24.0"
+    "@rushstack/node-core-library" "3.30.0"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -4522,6 +4524,11 @@ import-fresh@^3.0.0, import-fresh@^3.1.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-lazy@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+
 import-local@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
@@ -7443,7 +7450,7 @@ resolve@^1.12.0, resolve@^1.13.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.17.0:
+resolve@^1.17.0, resolve@~1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -7616,7 +7623,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2:
+semver@^7.3.2, semver@~7.3.0:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==


### PR DESCRIPTION
This bump includes https://github.com/microsoft/rushstack/pull/2132 which fixes an issue where in some edge cases, it's trying to hash a deleted file and fails.