### PR TITLE
Use workspace root instead of git root

### DIFF
--- a/change/backfill-2020-10-13-10-07-05-bewegger-workspace-root.json
+++ b/change/backfill-2020-10-13-10-07-05-bewegger-workspace-root.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use workspace root instead of git root",
+  "packageName": "backfill",
+  "email": "bewegger@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-13T08:07:02.210Z"
+}

--- a/change/backfill-hasher-2020-10-13-10-07-05-bewegger-workspace-root.json
+++ b/change/backfill-hasher-2020-10-13-10-07-05-bewegger-workspace-root.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use workspace root instead of git root",
+  "packageName": "backfill-hasher",
+  "email": "bewegger@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-13T08:07:05.808Z"
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "lerna run --stream build",
     "change": "beachball change --scope \"!packages/utils-test/__fixtures__/*\"",
-    "checkchange": "beachball check",
+    "checkchange": "beachball check --scope \"!packages/utils-test/__fixtures__/*\"",
     "postinstall": "yarn update-project-references",
     "lerna": "lerna",
     "lint": "eslint --fix . --ext .ts",

--- a/packages/backfill/src/__tests__/e2e.test.ts
+++ b/packages/backfill/src/__tests__/e2e.test.ts
@@ -24,7 +24,7 @@ describe("End to end", () => {
 
     // Verify it produces the correct hash
     const ownHash = fs.readdirSync(path.join(packageRoot, hashPath));
-    expect(ownHash).toContain("a08f2c997819b9bb8fda511d722ce9e31ba6fd6f");
+    expect(ownHash).toContain("bd773dfb416fdbf46e6cb3defd061f514f3cbb45");
 
     // ... and that `npm run compile` was run successfully
     const libFolderExist = await fs.pathExists(path.join(packageRoot, "lib"));

--- a/packages/backfill/src/__tests__/e2e.test.ts
+++ b/packages/backfill/src/__tests__/e2e.test.ts
@@ -24,7 +24,7 @@ describe("End to end", () => {
 
     // Verify it produces the correct hash
     const ownHash = fs.readdirSync(path.join(packageRoot, hashPath));
-    expect(ownHash).toContain("af55fcac0431e6f6ce143083e53c1a398b87fc74");
+    expect(ownHash).toContain("a08f2c997819b9bb8fda511d722ce9e31ba6fd6f");
 
     // ... and that `npm run compile` was run successfully
     const libFolderExist = await fs.pathExists(path.join(packageRoot, "lib"));

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -21,7 +21,7 @@
     "backfill-logger": "^5.0.0",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",
-    "workspace-tools": "^0.9.0"
+    "workspace-tools": "^0.10.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",

--- a/packages/hasher/src/__tests__/hashOfFiles.test.ts
+++ b/packages/hasher/src/__tests__/hashOfFiles.test.ts
@@ -76,6 +76,6 @@ describe("generateHashOfFiles()", () => {
 
     const hashOfPackage = await generateHashOfFiles(packageRoot, repoInfo);
 
-    expect(hashOfPackage).toEqual("75d811452b9f8561c7827df9a8f18ac8cb44df9a");
+    expect(hashOfPackage).toEqual("4d4ca2ecc436e1198554f5d03236ea8f956ac0c4");
   });
 });

--- a/packages/hasher/src/repoInfo.ts
+++ b/packages/hasher/src/repoInfo.ts
@@ -1,7 +1,7 @@
 import {
   WorkspaceInfo,
   ParsedLock,
-  findGitRoot,
+  getWorkspaceRoot,
   getWorkspaces,
   parseLockFile
 } from "workspace-tools";
@@ -30,13 +30,13 @@ function searchRepoInfoCache(packageRoot: string) {
 }
 
 export async function getRepoInfoNoCache(cwd: string) {
-  const root = findGitRoot(cwd);
+  const root = getWorkspaceRoot(cwd);
   if (!root) {
-    throw new Error("Cannot initialize Repo class without a .git root");
+    throw new Error("Cannot initialize Repo class without a workspace root");
   }
 
   const repoHashes = getPackageDeps(root).files;
-  const workspaceInfo = await getWorkspaces(root);
+  const workspaceInfo = getWorkspaces(root);
   const parsedLock = await parseLockFile(root);
 
   const repoInfo = {

--- a/packages/utils-test/__fixtures__/basic/package.json
+++ b/packages/utils-test/__fixtures__/basic/package.json
@@ -2,6 +2,11 @@
   "name": "basic",
   "license": "MIT",
   "version": "0.1.0",
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  },
   "scripts": {
     "compile": "node node_modules/.bin/copy src/index.ts lib/index.js"
   },

--- a/packages/utils-test/__fixtures__/empty/package.json
+++ b/packages/utils-test/__fixtures__/empty/package.json
@@ -1,5 +1,10 @@
 {
   "name": "empty",
   "license": "MIT",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8812,10 +8812,10 @@ wordwrap@^1.0.0, wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-workspace-tools@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.9.0.tgz#5ce0680c9bf38544d1f6261d6b0e2834347e676e"
-  integrity sha512-ji9mOpdxyJ1LBnCzfFzAuLw7x0OuqQso/eJFpeyR/W0nXRK3Uhmn0dAaqrlDlrUEW5nOT5nSz0MpsaCmeSyiUA==
+workspace-tools@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.10.0.tgz#82b4a0ec17350cb27df51c3f8b0c2d1e394b3d26"
+  integrity sha512-6rwbc4H6bSn74RfSwzSButqx602rzTTtxA9m+9RSzMpuXrFmNHfJGppn0Pi5J+LgP56ZA5VwfP7/nHN1fS8frg==
   dependencies:
     "@pnpm/lockfile-file" "^3.0.7"
     "@pnpm/logger" "^3.2.2"


### PR DESCRIPTION
This PR uses `getWorkspaceRoot()` instead of `findGitRoot()` to determine the root of the monorepo. Some of the fixtures were updated to include workspace information causing some of the hashes in the tests to update.