### PR TITLE
Add syntax highlighting to a code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ BACKFILL_CACHE_PROVIDER="local-skip"
 Backfill provides an API, this allows for more complex scenarios, and
 performance optimizations.
 
-```
+```js
 const backfill = require("backfill/lib/api");
 
 const packagePath = getPath(packageName);


### PR DESCRIPTION
The code sample near the bottom of the page showing how to use the javascript api lacks syntax highlight, this PR adds the tag to the code block that should enable it.