### PR TITLE
Fix: files from a different package are included in the hash.

### DIFF
--- a/change/backfill-hasher-2021-06-22-16-15-08-vibailly-fix-hash-of-files.json
+++ b/change/backfill-hasher-2021-06-22-16-15-08-vibailly-fix-hash-of-files.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix: files from a different package are included in the hash.",
+  "packageName": "backfill-hasher",
+  "email": "vibailly@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-22T14:15:07.971Z"
+}

--- a/packages/hasher/src/__tests__/hashOfFiles.test.ts
+++ b/packages/hasher/src/__tests__/hashOfFiles.test.ts
@@ -39,6 +39,31 @@ describe("generateHashOfFiles()", () => {
     expect(hashOfPackage).toEqual(hashOfPackageWithoutFoo);
   });
 
+  it("is not confused by package names being substring of other packages", async () => {
+    const packageRoot = await setupFixture("monorepo");
+
+    let repoInfo = await getRepoInfoNoCache(packageRoot);
+
+    const hashOfPackageA = await generateHashOfFiles(
+      path.join(packageRoot, "packages", "package-a"),
+      repoInfo
+    );
+
+    await fs.mkdir(path.join(packageRoot, "packages", "package-abc"));
+    await fs.writeFile(
+      path.join(packageRoot, "packages", "package-abc", "foo"),
+      "bar"
+    );
+
+    repoInfo = await getRepoInfoNoCache(packageRoot);
+    const newHashOfPackageA = await generateHashOfFiles(
+      path.join(packageRoot, "packages", "package-a"),
+      repoInfo
+    );
+
+    expect(hashOfPackageA).toEqual(newHashOfPackageA);
+  });
+
   it("file paths are included in hash", async () => {
     const packageRoot = await setupFixture("empty");
 
@@ -63,7 +88,7 @@ describe("generateHashOfFiles()", () => {
   });
 
   // This test will be run on Windows and on Linux on the CI
-  it.only("file paths are consistent across platforms", async () => {
+  it("file paths are consistent across platforms", async () => {
     const packageRoot = await setupFixture("empty");
 
     // Create a folder to make sure we get folder separators as part of the file name

--- a/packages/hasher/src/hashOfFiles.ts
+++ b/packages/hasher/src/hashOfFiles.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path, { sep } from "path";
 
 import { hashStrings } from "./helpers";
 import { RepoInfo } from "./repoInfo";
@@ -24,7 +24,7 @@ export async function generateHashOfFiles(
   const { repoHashes, root } = repoInfo;
 
   const files: string[] = Object.keys(repoHashes).filter((f) =>
-    path.join(root, f).includes(path.normalize(packageRoot) + "/")
+    path.join(root, f).includes(path.normalize(packageRoot) + sep)
   );
 
   files.sort((a, b) => a.localeCompare(b));

--- a/packages/hasher/src/hashOfFiles.ts
+++ b/packages/hasher/src/hashOfFiles.ts
@@ -24,7 +24,7 @@ export async function generateHashOfFiles(
   const { repoHashes, root } = repoInfo;
 
   const files: string[] = Object.keys(repoHashes).filter((f) =>
-    path.join(root, f).includes(path.normalize(packageRoot))
+    path.join(root, f).includes(path.normalize(packageRoot) + "/")
   );
 
   files.sort((a, b) => a.localeCompare(b));


### PR DESCRIPTION
When a package is a substring of another package, the files in the
package which have the longuest name will affect the hash of the other.