### PR TITLE
Improve the speed of put as the number o files in cwd increases to >10k

### DIFF
--- a/change/backfill-cache-2021-07-31-09-52-38-put-speed.json
+++ b/change/backfill-cache-2021-07-31-09-52-38-put-speed.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Speeds up put memoized hash calculation as well as fixing a bug in the path normalization",
+  "packageName": "backfill-cache",
+  "email": "ken@gizzar.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-31T16:52:38.076Z"
+}

--- a/packages/cache/src/CacheStorage.ts
+++ b/packages/cache/src/CacheStorage.ts
@@ -40,16 +40,13 @@ function getMemoizedHashesFor(cwd: string): { [file: string]: string } {
     (o) => !relative(pathRelativeToRepo, o).startsWith("..")
   );
 
-  return filesInCwd.reduce(
-    (acc, next) => ({
-      ...acc,
-      [relative(pathRelativeToRepo, next).replace(
-        /\\/,
-        "/"
-      )]: savedHashOfThisRepo[next],
-    }),
-    {}
-  );
+  const results: { [key: string]: string } = {};
+  for (const file in filesInCwd) {
+    results[relative(pathRelativeToRepo, file).replace(/\\/g, "/")] =
+      savedHashOfThisRepo[file];
+  }
+
+  return results;
 }
 
 export interface ICacheStorage {


### PR DESCRIPTION
The algorithm I'm replacing was creating a new copy of the object over and over again. This is okay for a small number of files in a "filesInCwd", but if we begin looking at memoizing hashes for a large number of files, it becomes really slow!