### PR TITLE
Fix git root detection in worktrees

### DIFF
--- a/change/backfill-2021-09-20-22-47-29-worktrees.json
+++ b/change/backfill-2021-09-20-22-47-29-worktrees.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix git root detection in worktrees",
+  "packageName": "backfill",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-09-21T05:47:28.208Z"
+}

--- a/change/backfill-cache-2021-09-20-22-47-29-worktrees.json
+++ b/change/backfill-cache-2021-09-20-22-47-29-worktrees.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix git root detection in worktrees",
+  "packageName": "backfill-cache",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-09-21T05:47:29.059Z"
+}

--- a/packages/backfill/src/audit.ts
+++ b/packages/backfill/src/audit.ts
@@ -12,11 +12,13 @@ let watcher: chokidar.FSWatcher;
 
 function getGitRepositoryRoot(packageRoot: string) {
   // .git is typically a folder but will be a file in a worktree
-  const nearestGitFolder = findUp.sync(".git", { cwd: packageRoot });
+  const nearestGitRoot =
+    findUp.sync(".git", { cwd: packageRoot, type: "directory" }) ||
+    findUp.sync(".git", { cwd: packageRoot, type: "file" });
 
-  if (nearestGitFolder) {
+  if (nearestGitRoot) {
     // Return the parent folder of some/path/.git
-    return path.join(nearestGitFolder, "..");
+    return path.join(nearestGitRoot, "..");
   }
 
   return packageRoot;

--- a/packages/backfill/src/audit.ts
+++ b/packages/backfill/src/audit.ts
@@ -12,13 +12,13 @@ let watcher: chokidar.FSWatcher;
 
 function getGitRepositoryRoot(packageRoot: string) {
   // .git is typically a folder but will be a file in a worktree
-  const nearestGitRoot =
+  const nearestGitInfo =
     findUp.sync(".git", { cwd: packageRoot, type: "directory" }) ||
     findUp.sync(".git", { cwd: packageRoot, type: "file" });
 
-  if (nearestGitRoot) {
+  if (nearestGitInfo) {
     // Return the parent folder of some/path/.git
-    return path.join(nearestGitRoot, "..");
+    return path.join(nearestGitInfo, "..");
   }
 
   return packageRoot;

--- a/packages/backfill/src/audit.ts
+++ b/packages/backfill/src/audit.ts
@@ -11,10 +11,8 @@ let changedFilesInsideScope: string[] = [];
 let watcher: chokidar.FSWatcher;
 
 function getGitRepositoryRoot(packageRoot: string) {
-  const nearestGitFolder = findUp.sync(".git", {
-    cwd: packageRoot,
-    type: "directory",
-  });
+  // .git is typically a folder but will be a file in a worktree
+  const nearestGitFolder = findUp.sync(".git", { cwd: packageRoot });
 
   if (nearestGitFolder) {
     // Return the parent folder of some/path/.git

--- a/packages/cache/src/CacheStorage.ts
+++ b/packages/cache/src/CacheStorage.ts
@@ -9,14 +9,16 @@ const savedHashOfRepos: { [gitRoot: string]: { [file: string]: string } } = {};
 
 function getRepoRoot(cwd: string): string {
   // .git is typically a folder but will be a file in a worktree
-  const gitFolder = findUp.sync(".git", { cwd });
-  if (!gitFolder) {
+  const gitRoot =
+    findUp.sync(".git", { cwd, type: "directory" }) ||
+    findUp.sync(".git", { cwd, type: "file" });
+  if (!gitRoot) {
     throw new Error(
       "The location that backfill is being run against is not in a git repo"
     );
   }
 
-  return dirname(gitFolder);
+  return dirname(gitRoot);
 }
 
 function fetchHashesFor(cwd: string) {

--- a/packages/cache/src/CacheStorage.ts
+++ b/packages/cache/src/CacheStorage.ts
@@ -9,16 +9,16 @@ const savedHashOfRepos: { [gitRoot: string]: { [file: string]: string } } = {};
 
 function getRepoRoot(cwd: string): string {
   // .git is typically a folder but will be a file in a worktree
-  const gitRoot =
+  const nearestGitInfo =
     findUp.sync(".git", { cwd, type: "directory" }) ||
     findUp.sync(".git", { cwd, type: "file" });
-  if (!gitRoot) {
+  if (!nearestGitInfo) {
     throw new Error(
       "The location that backfill is being run against is not in a git repo"
     );
   }
 
-  return dirname(gitRoot);
+  return dirname(nearestGitInfo);
 }
 
 function fetchHashesFor(cwd: string) {

--- a/packages/cache/src/CacheStorage.ts
+++ b/packages/cache/src/CacheStorage.ts
@@ -8,7 +8,8 @@ import { Logger } from "backfill-logger";
 const savedHashOfRepos: { [gitRoot: string]: { [file: string]: string } } = {};
 
 function getRepoRoot(cwd: string): string {
-  const gitFolder = findUp.sync(".git", { cwd, type: "directory" });
+  // .git is typically a folder but will be a file in a worktree
+  const gitFolder = findUp.sync(".git", { cwd });
   if (!gitFolder) {
     throw new Error(
       "The location that backfill is being run against is not in a git repo"


### PR DESCRIPTION
`.git` is typically a folder, but it will be a file in a [git worktree](https://git-scm.com/docs/git-worktree). Handle that case properly.