### PR TITLE
Speeding up hasher by reducing wasted calculations

### DIFF
--- a/change/backfill-hasher-2022-01-06-14-58-42-speed.json
+++ b/change/backfill-hasher-2022-01-06-14-58-42-speed.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "speeding up the hasher by reducing wasted calculations",
+  "packageName": "backfill-hasher",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-01-06T22:58:42.192Z"
+}

--- a/packages/hasher/src/hashOfFiles.ts
+++ b/packages/hasher/src/hashOfFiles.ts
@@ -23,8 +23,12 @@ export async function generateHashOfFiles(
 ): Promise<string> {
   const { repoHashes, root } = repoInfo;
 
+  const normalized = path.normalize(packageRoot) + sep;
+
   const files: string[] = Object.keys(repoHashes).filter((f) =>
-    path.join(root, f).includes(path.normalize(packageRoot) + sep)
+    // purposefully using string concat here to speed up the checks since root and f
+    // are well formatted from "getWorkspaceRoot" and "repoHashes"
+    (root + sep + f).includes(normalized)
   );
 
   files.sort((a, b) => a.localeCompare(b));


### PR DESCRIPTION
1. we should only normalize the path ONCE per package (maybe even THAT can be optimized)
2. path.join should not be used on this tight loop
