### PR TITLE
Fix platform diffs

### DIFF
--- a/change/backfill-hasher-2022-01-13-11-35-21-fix-platform-diffs.json
+++ b/change/backfill-hasher-2022-01-13-11-35-21-fix-platform-diffs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixing platform differences in a monorepo, added tests",
+  "packageName": "backfill-hasher",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-01-13T19:35:21.939Z"
+}

--- a/packages/hasher/src/__tests__/hashOfFiles.test.ts
+++ b/packages/hasher/src/__tests__/hashOfFiles.test.ts
@@ -105,7 +105,7 @@ describe("generateHashOfFiles()", () => {
   });
 
   // This test will be run on Windows and on Linux on the CI
-  it.only("file paths in a monorepo are consistent across platforms", async () => {
+  it("file paths in a monorepo are consistent across platforms", async () => {
     const workspaceRoot = await setupFixture("empty");
 
     // Create a folder to make sure we get folder separators as part of the file name

--- a/packages/hasher/src/__tests__/hashOfFiles.test.ts
+++ b/packages/hasher/src/__tests__/hashOfFiles.test.ts
@@ -103,4 +103,21 @@ describe("generateHashOfFiles()", () => {
 
     expect(hashOfPackage).toEqual("4d4ca2ecc436e1198554f5d03236ea8f956ac0c4");
   });
+
+  // This test will be run on Windows and on Linux on the CI
+  it.only("file paths in a monorepo are consistent across platforms", async () => {
+    const workspaceRoot = await setupFixture("empty");
+
+    // Create a folder to make sure we get folder separators as part of the file name
+    const folder = path.join(workspaceRoot, "packages", "foo");
+
+    fs.mkdirpSync(folder);
+
+    fs.writeFileSync(path.join(folder, "foo.txt"), "bar");
+    let repoInfo = await getRepoInfoNoCache(workspaceRoot);
+
+    const hashOfPackage = await generateHashOfFiles(folder, repoInfo);
+
+    expect(hashOfPackage).toEqual("438b5f734e6de1ef0eb9114a28ef230a9ff83f54");
+  });
 });

--- a/packages/hasher/src/hashOfFiles.ts
+++ b/packages/hasher/src/hashOfFiles.ts
@@ -26,9 +26,7 @@ export async function generateHashOfFiles(
   const normalized = path.normalize(packageRoot) + sep;
 
   const files: string[] = Object.keys(repoHashes).filter((f) =>
-    // purposefully using string concat here to speed up the checks since root and f
-    // are well formatted from "getWorkspaceRoot" and "repoHashes"
-    (root + sep + f).includes(normalized)
+    path.join(root, f).includes(normalized)
   );
 
   files.sort((a, b) => a.localeCompare(b));


### PR DESCRIPTION
In optimizing backfill hasher, the platform diffs surfaced. Unfortunately, the existing test didn't cover the monorepo case. I've since added a test for this case. I was doing all my local validation in Linux and missed the Windows case. This has been locally & unit tested now.