### PR TITLE
Fix filesInCwd loop

### DIFF
--- a/change/backfill-cache-2022-03-24-17-11-07-fix-fileInCwd-loop.json
+++ b/change/backfill-cache-2022-03-24-17-11-07-fix-fileInCwd-loop.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix filesInCwd loop",
+  "packageName": "backfill-cache",
+  "email": "rnjuguna@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-03-24T14:11:07.264Z"
+}

--- a/packages/cache/src/CacheStorage.ts
+++ b/packages/cache/src/CacheStorage.ts
@@ -45,7 +45,7 @@ function getMemoizedHashesFor(cwd: string): { [file: string]: string } {
   );
 
   const results: { [key: string]: string } = {};
-  for (const file in filesInCwd) {
+  for (const file of filesInCwd) {
     results[relative(pathRelativeToRepo, file).replace(/\\/g, "/")] =
       savedHashOfThisRepo[file];
   }


### PR DESCRIPTION
The loop used to get the files in the filesInCwd array was assuming that the filesInCwd variable was an object. The change fixes the loop