### PR TITLE
Updating package-deps-hash version.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [12, 14]
+        node-version: [12, 14]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node_version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.node-version }}
 
       - name: yarn install
         run: yarn install

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Run on node ${{ matrix.node_version }} and ${{ matrix.os }}
+    name: Run on node ${{ matrix.node-version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/change/backfill-cache-2022-03-30-18-11-10-fix-dep-hash.json
+++ b/change/backfill-cache-2022-03-30-18-11-10-fix-dep-hash.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Upgrading package-deps-hash version.",
+  "packageName": "backfill-cache",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-03-31T01:11:07.432Z"
+}

--- a/change/backfill-hasher-2022-03-30-18-11-10-fix-dep-hash.json
+++ b/change/backfill-hasher-2022-03-30-18-11-10-fix-dep-hash.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Upgrading package-deps-hash version.",
+  "packageName": "backfill-hasher",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-03-31T01:11:10.484Z"
+}

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@azure/storage-blob": "12.1.2",
-    "@rushstack/package-deps-hash": "^2.4.48",
+    "@rushstack/package-deps-hash": "^3.2.4",
     "backfill-config": "^6.2.0",
     "backfill-logger": "^5.1.3",
     "execa": "^4.0.0",

--- a/packages/cache/src/CacheStorage.ts
+++ b/packages/cache/src/CacheStorage.ts
@@ -26,7 +26,7 @@ function fetchHashesFor(cwd: string) {
   const gitRoot = getRepoRoot(cwd);
 
   savedHashOfRepos[gitRoot] ||
-    (savedHashOfRepos[gitRoot] = getPackageDeps(gitRoot).files);
+    (savedHashOfRepos[gitRoot] = Object.fromEntries(getPackageDeps(gitRoot)));
 }
 
 function getMemoizedHashesFor(cwd: string): { [file: string]: string } {
@@ -78,7 +78,7 @@ export abstract class CacheStorage implements ICacheStorage {
     const filesMatchingOutputGlob = await globby(outputGlob, { cwd: this.cwd });
 
     // Get the list of files that have not changed so we don't need to cache them.
-    const hashesNow = getPackageDeps(this.cwd).files;
+    const hashesNow = Object.fromEntries(getPackageDeps(this.cwd));
     const hashesThen = getMemoizedHashesFor(this.cwd);
     const unchangedFiles = Object.keys(hashesThen).filter(
       (s) => hashesThen[s] === hashesNow[s]

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -16,7 +16,7 @@
     "watch": "tsc -b -w"
   },
   "dependencies": {
-    "@rushstack/package-deps-hash": "^2.4.48",
+    "@rushstack/package-deps-hash": "^3.2.4",
     "backfill-config": "^6.2.0",
     "backfill-logger": "^5.1.3",
     "find-up": "^5.0.0",

--- a/packages/hasher/src/repoInfo.ts
+++ b/packages/hasher/src/repoInfo.ts
@@ -35,7 +35,7 @@ export async function getRepoInfoNoCache(cwd: string) {
     throw new Error("Cannot initialize Repo class without a workspace root");
   }
 
-  const repoHashes = getPackageDeps(root).files;
+  const repoHashes = Object.fromEntries(getPackageDeps(root));
   const workspaceInfo = getWorkspaces(root);
   const parsedLock = await parseLockFile(root);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,12 +1531,12 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.6.1.tgz#b260e454ee4f9635ea024fc83be225e397f15363"
   integrity sha512-5bHhlTBBq82ti3qPT15TRxkYTFPPQWbnkkQkmHPtqiS1XcTB69cEKd3Jm7Cfi/vkPoyxapmePE9tyA7EzLt8SQ==
 
-"@rushstack/node-core-library@3.34.1":
-  version "3.34.1"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.34.1.tgz#36368179bb7a80afced4c3bb68387b7fc5381b3a"
-  integrity sha512-DX1xB9E2Xmi5auFxacftUXVuI2DUUyKrlGaecjesiS2YmV6pBnKzHHAaxWOQF2ajFNhXY2I1cGvDp45z3aJv5g==
+"@rushstack/node-core-library@3.45.1":
+  version "3.45.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.45.1.tgz#787361b61a48d616eb4b059641721a3dc138f001"
+  integrity sha512-BwdssTNe007DNjDBxJgInHg8ePytIPyT0La7ZZSQZF9+rSkT42AygXPGvbGsyFfEntjr4X37zZSJI7yGzL16cQ==
   dependencies:
-    "@types/node" "10.17.13"
+    "@types/node" "12.20.24"
     colors "~1.2.1"
     fs-extra "~7.0.1"
     import-lazy "~4.0.0"
@@ -1544,14 +1544,14 @@
     resolve "~1.17.0"
     semver "~7.3.0"
     timsort "~0.3.0"
-    z-schema "~3.18.3"
+    z-schema "~5.0.2"
 
-"@rushstack/package-deps-hash@^2.4.48":
-  version "2.4.70"
-  resolved "https://registry.yarnpkg.com/@rushstack/package-deps-hash/-/package-deps-hash-2.4.70.tgz#6148960c799873d04effdebedbb517f263d804f6"
-  integrity sha512-NeyjGQlrdiVym22GvF7B7+9BhzKCyaMUztq1CVXYeTCI41G8PQhxGnFyWQ96wdGSjItZ1eO2QuTR+S5v3MDlhw==
+"@rushstack/package-deps-hash@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@rushstack/package-deps-hash/-/package-deps-hash-3.2.4.tgz#f62a15d499e4e29b80f8f71642e7a4ad6d5e7748"
+  integrity sha512-XtJug6VClsWAjwMgAE9nzC9mYStYCOkLb8KOUDEt6fhgV+MJcuKHsdIe7jXCoew+LJUyQoofoFDRG4ideo9X+g==
   dependencies:
-    "@rushstack/node-core-library" "3.34.1"
+    "@rushstack/node-core-library" "3.45.1"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -1707,10 +1707,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
-"@types/node@10.17.13":
-  version "10.17.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
-  integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
+"@types/node@12.20.24":
+  version "12.20.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.24.tgz#c37ac69cb2948afb4cef95f424fa0037971a9a5c"
+  integrity sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -5613,12 +5613,12 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.get@^4.0.0, lodash.get@^4.4.2:
+lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
-lodash.isequal@^4.0.0:
+lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -8584,10 +8584,10 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validator@^8.0.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-8.2.0.tgz#3c1237290e37092355344fef78c231249dab77b9"
-  integrity sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==
+validator@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
 verror@1.10.0:
   version "1.10.0"
@@ -8959,13 +8959,13 @@ yargs@^16.1.1:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-z-schema@~3.18.3:
-  version "3.18.4"
-  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-3.18.4.tgz#ea8132b279533ee60be2485a02f7e3e42541a9a2"
-  integrity sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
+z-schema@~5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-5.0.2.tgz#f410394b2c9fcb9edaf6a7511491c0bb4e89a504"
+  integrity sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==
   dependencies:
-    lodash.get "^4.0.0"
-    lodash.isequal "^4.0.0"
-    validator "^8.0.0"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    validator "^13.7.0"
   optionalDependencies:
     commander "^2.7.1"


### PR DESCRIPTION
We are seeing a bad rush dependency being pulled in from this dependency branch:

```
lage@1.5.1 (latest:
  backfill@6.1.13
    backfill-cache@5.3.0 (NEEDS upgrade)
      @rushstack/package-deps-hash@2.4.110 (EXACT DEP HERE??)
        @rushstack/node-core-library@3.35.2 (This branch locks us into 8.2.0)
          z-schema@3.18.4
            validator@8.2.0
```
