### PR TITLE
opt in for incremental caching

### DIFF
--- a/change/backfill-2022-05-18-13-14-29-HEAD.json
+++ b/change/backfill-2022-05-18-13-14-29-HEAD.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Make incremental cache an opt-in option",
+  "packageName": "backfill",
+  "email": "vibailly@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-05-18T11:14:12.175Z"
+}

--- a/change/backfill-cache-2022-05-18-13-14-29-HEAD.json
+++ b/change/backfill-cache-2022-05-18-13-14-29-HEAD.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Make incremental cache an opt-in option",
+  "packageName": "backfill-cache",
+  "email": "vibailly@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-05-18T11:14:24.414Z"
+}

--- a/change/backfill-config-2022-05-18-13-14-29-HEAD.json
+++ b/change/backfill-config-2022-05-18-13-14-29-HEAD.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Make incremental cache an opt-in option",
+  "packageName": "backfill-config",
+  "email": "vibailly@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-05-18T11:14:29.510Z"
+}

--- a/packages/backfill/src/api.ts
+++ b/packages/backfill/src/api.ts
@@ -67,17 +67,25 @@ export async function fetch(
   cwd: string,
   hash: string,
   logger: Logger,
-  config?: Pick<Config, "cacheStorageConfig" | "internalCacheFolder">
+  config?: Pick<
+    Config,
+    "cacheStorageConfig" | "internalCacheFolder" | "incrementalCaching"
+  >
 ): Promise<boolean> {
   if (!config) {
     config = createConfig(logger, cwd);
   }
-  const { cacheStorageConfig, internalCacheFolder } = config;
+  const {
+    cacheStorageConfig,
+    internalCacheFolder,
+    incrementalCaching,
+  } = config;
   const cacheStorage = getCacheStorageProvider(
     cacheStorageConfig,
     internalCacheFolder,
     logger,
-    cwd
+    cwd,
+    incrementalCaching
   );
   const fetch = await cacheStorage.fetch(hash);
   return fetch;
@@ -89,18 +97,27 @@ export async function put(
   logger: Logger,
   config?: Pick<
     Config,
-    "cacheStorageConfig" | "internalCacheFolder" | "outputGlob"
+    | "cacheStorageConfig"
+    | "internalCacheFolder"
+    | "outputGlob"
+    | "incrementalCaching"
   >
 ): Promise<void> {
   if (!config) {
     config = createConfig(logger, cwd);
   }
-  const { cacheStorageConfig, internalCacheFolder, outputGlob } = config;
+  const {
+    cacheStorageConfig,
+    internalCacheFolder,
+    outputGlob,
+    incrementalCaching,
+  } = config;
   const cacheStorage = getCacheStorageProvider(
     cacheStorageConfig,
     internalCacheFolder,
     logger,
-    cwd
+    cwd,
+    incrementalCaching
   );
   await cacheStorage.put(hash, outputGlob);
 }

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -34,9 +34,10 @@ export class AzureBlobCacheStorage extends CacheStorage {
   constructor(
     private options: AzureBlobCacheStorageOptions,
     logger: Logger,
-    cwd: string
+    cwd: string,
+    incrementalCaching = false
   ) {
-    super(logger, cwd);
+    super(logger, cwd, incrementalCaching);
   }
 
   protected async _fetch(hash: string): Promise<boolean> {

--- a/packages/cache/src/LocalCacheStorage.ts
+++ b/packages/cache/src/LocalCacheStorage.ts
@@ -9,9 +9,10 @@ export class LocalCacheStorage extends CacheStorage {
   constructor(
     private internalCacheFolder: string,
     logger: Logger,
-    cwd: string
+    cwd: string,
+    incrementalCaching = false
   ) {
-    super(logger, cwd);
+    super(logger, cwd, incrementalCaching);
   }
 
   protected getLocalCacheFolder(hash: string): string {

--- a/packages/cache/src/LocalSkipCacheStorage.ts
+++ b/packages/cache/src/LocalSkipCacheStorage.ts
@@ -12,9 +12,10 @@ export class LocalSkipCacheStorage extends CacheStorage {
   constructor(
     private internalCacheFolder: string,
     logger: Logger,
-    cwd: string
+    cwd: string,
+    incrementalCaching = false
   ) {
-    super(logger, cwd);
+    super(logger, cwd, incrementalCaching);
   }
 
   protected getLocalCacheFolder(hash: string): string {

--- a/packages/cache/src/NpmCacheStorage.ts
+++ b/packages/cache/src/NpmCacheStorage.ts
@@ -13,9 +13,10 @@ export class NpmCacheStorage extends CacheStorage {
     private options: NpmCacheStorageOptions,
     private internalCacheFolder: string,
     logger: Logger,
-    cwd: string
+    cwd: string,
+    incrementalCaching = false
   ) {
-    super(logger, cwd);
+    super(logger, cwd, incrementalCaching);
   }
 
   protected async _fetch(hash: string): Promise<boolean> {

--- a/packages/cache/src/__tests__/cacheStorage.test.ts
+++ b/packages/cache/src/__tests__/cacheStorage.test.ts
@@ -7,7 +7,7 @@ import { CacheStorage } from "../CacheStorage";
 export class LocalCacheStorage extends CacheStorage {
   filesToCache: string[] | undefined;
   constructor(logger: Logger, cwd: string) {
-    super(logger, cwd);
+    super(logger, cwd, true);
   }
 
   protected async _fetch(_hash: string): Promise<boolean> {

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -19,7 +19,8 @@ export function getCacheStorageProvider(
   cacheStorageConfig: CacheStorageConfig,
   internalCacheFolder: string,
   logger: Logger,
-  cwd: string
+  cwd: string,
+  incrementalCaching = false
 ): ICacheStorage {
   let cacheStorage: ICacheStorage;
 
@@ -41,22 +42,30 @@ export function getCacheStorageProvider(
         cacheStorageConfig.options,
         internalCacheFolder,
         logger,
-        cwd
+        cwd,
+        incrementalCaching
       );
     } else if (cacheStorageConfig.provider === "azure-blob") {
       cacheStorage = new AzureBlobCacheStorage(
         cacheStorageConfig.options,
         logger,
-        cwd
+        cwd,
+        incrementalCaching
       );
     } else if (cacheStorageConfig.provider === "local-skip") {
       cacheStorage = new LocalSkipCacheStorage(
         internalCacheFolder,
         logger,
-        cwd
+        cwd,
+        incrementalCaching
       );
     } else {
-      cacheStorage = new LocalCacheStorage(internalCacheFolder, logger, cwd);
+      cacheStorage = new LocalCacheStorage(
+        internalCacheFolder,
+        logger,
+        cwd,
+        incrementalCaching
+      );
     }
     memo.set(key, cacheStorage);
   }

--- a/packages/config/src/envConfig.ts
+++ b/packages/config/src/envConfig.ts
@@ -73,5 +73,10 @@ export function getEnvConfig(logger: Logger) {
     config["validateOutput"] = Boolean(validateOutput === "true");
   }
 
+  const incrementalCaching = process.env["BACKFILL_INCREMENTAL_CACHING"];
+  if (incrementalCaching) {
+    config["incrementalCaching"] = Boolean(incrementalCaching === "true");
+  }
+
   return config;
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -34,6 +34,7 @@ export type Config = {
   performanceReportName?: string;
   producePerformanceLogs: boolean;
   validateOutput: boolean;
+  incrementalCaching: boolean;
 };
 
 export function isCorrectMode(mode: string): mode is BackfillModes {
@@ -89,6 +90,7 @@ export function createDefaultConfig(fromPath: string): Config {
     packageRoot,
     producePerformanceLogs: false,
     validateOutput: false,
+    incrementalCaching: false,
   };
 }
 


### PR DESCRIPTION
Incremental caching is the feature of only storing to cache the files that have changed.

This feature is not desirable in every situation, so we make it optional.
To be on the conservative side, this option is off by default.

This feature can be turned on either by the backfill config file or by an environment variable.