### PR TITLE
azure blob timeout

### DIFF
--- a/change/backfill-cache-2022-05-18-14-47-12-HEAD.json
+++ b/change/backfill-cache-2022-05-18-14-47-12-HEAD.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Azure blob storage timeout",
+  "packageName": "backfill-cache",
+  "email": "vibailly@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-05-18T12:47:12.257Z"
+}


### PR DESCRIPTION
We are seeing some issues where the azure blob storage fetch seems to hangs.
This PR makes the call fail if the fetch takes more than 10min