### PR TITLE
fixes windows to use the fast path as well

### DIFF
--- a/change/backfill-hasher-2022-06-10-12-06-30-fix-windows-fast-path.json
+++ b/change/backfill-hasher-2022-06-10-12-06-30-fix-windows-fast-path.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixes windows to use the fast path as well",
+  "packageName": "backfill-hasher",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-06-10T19:06:30.606Z"
+}

--- a/packages/hasher/src/hashOfFiles.ts
+++ b/packages/hasher/src/hashOfFiles.ts
@@ -21,7 +21,9 @@ export async function generateHashOfFiles(
   const { repoHashes, root, packageHashes } = repoInfo;
 
   const hashes: string[] = [];
-  const packageRelativeRoot = path.relative(root, packageRoot);
+  const packageRelativeRoot = path
+    .relative(root, packageRoot)
+    .replace(/\\/g, "/");
 
   if (packageHashes[packageRelativeRoot]) {
     // Fast path: if files are clearly inside a package as per the packageHashes cache


### PR DESCRIPTION
Because the packageRoot from the getWorkspaces() returns a platform specific path sep, the switch to use the "fast path" was not activated on Windows (it still works as before, but it is just slower).

This change will address this issue by forcing the match with the "/" separator.