### PR TITLE
Improve how to run prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# generated or imported files
+CHANGELOG.*
+CODE_OF_CONDUCT.md
+SECURITY.md
+yarn.lock
+*.log
+
+# generated folders
+node_modules
+lib
+change
+__snapshots__
+
+# config files that don't need formatting
+.husky
+.prettierignore

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,4 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/backfill.config.js
+++ b/backfill.config.js
@@ -2,8 +2,8 @@ const path = require("path");
 
 module.exports = {
   cacheStorageConfig: {
-    provider: "local"
+    provider: "local",
   },
   logFolder: path.join(__dirname, ".backfill-logs"),
-  logLevel: "silly"
+  logLevel: "silly",
 };

--- a/change/backfill-cache-19c6df17-c4b0-4db7-b72b-1fc300604e79.json
+++ b/change/backfill-cache-19c6df17-c4b0-4db7-b72b-1fc300604e79.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update formatting with latest prettier version",
+  "packageName": "backfill-cache",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/backfill-config-99ee8b0c-205d-4781-ba7a-8cd991b78feb.json
+++ b/change/backfill-config-99ee8b0c-205d-4781-ba7a-8cd991b78feb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update formatting with latest prettier version",
+  "packageName": "backfill-config",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/backfill-ecaeecc1-13f5-4d1d-8d99-7455daa3e119.json
+++ b/change/backfill-ecaeecc1-13f5-4d1d-8d99-7455daa3e119.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update formatting with latest prettier version",
+  "packageName": "backfill",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/backfill-hasher-67a27c9d-653e-4ea7-98f6-9583b49bd447.json
+++ b/change/backfill-hasher-67a27c9d-653e-4ea7-98f6-9583b49bd447.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update formatting with latest prettier version",
+  "packageName": "backfill-hasher",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "lerna run --stream build",
     "change": "beachball change",
     "checkchange": "beachball check",
+    "format": "prettier --write .",
     "postinstall": "yarn update-project-references",
     "lerna": "lerna",
     "lint": "eslint --fix . --ext .ts",
@@ -21,7 +22,6 @@
     "prepublishOnly": "eslint . --ext .ts && lerna run build && lerna run test",
     "release": "beachball publish",
     "test": "lerna run test",
-    "prettier": "prettier \"{.,**}/*.{tsx,ts,js,json,md,yaml}\" --write",
     "update-project-references": "node tools/update-project-references.js",
     "watch": "lerna run watch --parallel"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "lerna": "3.22.1",
-    "prettier": "2.2.0",
+    "prettier": "2.7.1",
     "typescript": "4.1.2"
   },
   "devDependencies": {

--- a/packages/backfill/src/api.ts
+++ b/packages/backfill/src/api.ts
@@ -75,11 +75,8 @@ export async function fetch(
   if (!config) {
     config = createConfig(logger, cwd);
   }
-  const {
-    cacheStorageConfig,
-    internalCacheFolder,
-    incrementalCaching,
-  } = config;
+  const { cacheStorageConfig, internalCacheFolder, incrementalCaching } =
+    config;
   const cacheStorage = getCacheStorageProvider(
     cacheStorageConfig,
     internalCacheFolder,

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -74,9 +74,8 @@ function createBlobClient(
   containerName: string,
   blobName: string
 ) {
-  const blobServiceClient = BlobServiceClient.fromConnectionString(
-    connectionString
-  );
+  const blobServiceClient =
+    BlobServiceClient.fromConnectionString(connectionString);
   const containerClient = blobServiceClient.getContainerClient(containerName);
   const blobClient = containerClient.getBlobClient(blobName);
 

--- a/packages/cache/src/__tests__/LocalCacheStorage.test.ts
+++ b/packages/cache/src/__tests__/LocalCacheStorage.test.ts
@@ -56,11 +56,8 @@ async function fetchFromCache({
   hash,
   expectSuccess = true,
 }: CacheHelper) {
-  const {
-    cacheStorage,
-    internalCacheFolder,
-    fixtureLocation,
-  } = await setupCacheStorage(fixtureName);
+  const { cacheStorage, internalCacheFolder, fixtureLocation } =
+    await setupCacheStorage(fixtureName);
 
   const secretFile = "qwerty";
 
@@ -86,11 +83,8 @@ async function putInCache({
   expectSuccess = true,
   errorMessage,
 }: CacheHelper) {
-  const {
-    cacheStorage,
-    internalCacheFolder,
-    fixtureLocation,
-  } = await setupCacheStorage(fixtureName);
+  const { cacheStorage, internalCacheFolder, fixtureLocation } =
+    await setupCacheStorage(fixtureName);
 
   if (!outputGlob) {
     throw new Error("outputGlob should be provided to the putInCache function");

--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -122,8 +122,8 @@ describe("createConfig()", () => {
     const fixtureLocation = await setupFixture("basic");
     const config = createConfig(logger, fixtureLocation);
 
-    const defaultLocalCacheFolder = createDefaultConfig(fixtureLocation)
-      .internalCacheFolder;
+    const defaultLocalCacheFolder =
+      createDefaultConfig(fixtureLocation).internalCacheFolder;
     expect(config.internalCacheFolder).toStrictEqual(defaultLocalCacheFolder);
   });
 

--- a/packages/hasher/src/__tests__/index.test.ts
+++ b/packages/hasher/src/__tests__/index.test.ts
@@ -42,13 +42,8 @@ describe("addToQueue", () => {
   };
 
   it("adds internal dependencies to the queue", async () => {
-    const {
-      internalDependencies,
-      queue,
-      done,
-      workspaces,
-      packagePath,
-    } = await setupAddToQueue();
+    const { internalDependencies, queue, done, workspaces, packagePath } =
+      await setupAddToQueue();
 
     addToQueue(internalDependencies, queue, done, workspaces);
 
@@ -57,13 +52,8 @@ describe("addToQueue", () => {
   });
 
   it("doesn't add to the queue if the package has been evaluated", async () => {
-    let {
-      internalDependencies,
-      queue,
-      done,
-      workspaces,
-      packageToAdd,
-    } = await setupAddToQueue();
+    let { internalDependencies, queue, done, workspaces, packageToAdd } =
+      await setupAddToQueue();
 
     // Override
     done = [
@@ -81,13 +71,8 @@ describe("addToQueue", () => {
   });
 
   it("doesn't add to the queue if the package is already in the queue", async () => {
-    let {
-      internalDependencies,
-      queue,
-      done,
-      workspaces,
-      packagePath,
-    } = await setupAddToQueue();
+    let { internalDependencies, queue, done, workspaces, packagePath } =
+      await setupAddToQueue();
 
     // Override
     queue = [packagePath];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6763,10 +6763,10 @@ prettier-package-json@^2.1.0:
     sort-object-keys "^1.1.2"
     sort-order "^1.0.1"
 
-prettier@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
-  integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
+prettier@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"


### PR DESCRIPTION
Rather than running prettier on specific file extensions, in my experience/opinion it's better to have an appropriate ignore file and run prettier on all files.

Also, it's best if the command for running prettier is called `format` or something else instead of `prettier`, so that it's also possible to run the prettier binary directly (via `yarn prettier`) if desired.

I also updated Prettier to the latest version and formatted all files.