### PR TITLE
Run lint as part of CI build, and fix issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,11 +25,11 @@ jobs:
       - name: yarn install
         run: yarn install
 
-      - name: check changes
+      - name: verify change files
         run: yarn checkchange
 
-      - name: yarn build
-        run: yarn build
+      - run: yarn build
 
-      - name: yarn test
-        run: yarn test
+      - run: yarn lint
+
+      - run: yarn test

--- a/change/backfill-cache-e31d2e75-6804-4935-8641-eeee7820a687.json
+++ b/change/backfill-cache-e31d2e75-6804-4935-8641-eeee7820a687.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Simplify some logic to remove lint issues",
+  "packageName": "backfill-cache",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/cache/src/__tests__/cacheStorage.test.ts
+++ b/packages/cache/src/__tests__/cacheStorage.test.ts
@@ -10,7 +10,7 @@ class MockLocalCacheStorage extends CacheStorage {
     super(logger, cwd, true);
   }
 
-  protected async _fetch(_hash: string): Promise<boolean> {
+  protected async _fetch(): Promise<boolean> {
     return false;
   }
   protected async _put(_hash: string, filesToCache: string[]): Promise<void> {

--- a/packages/cache/src/hashFile.ts
+++ b/packages/cache/src/hashFile.ts
@@ -40,13 +40,17 @@ export async function getFileHash(
 ): Promise<string> {
   const fileAbsPath = path.join(cwd, filePath);
   const stat = await fs.stat(fileAbsPath);
-  if (memo.has(fileAbsPath) && memo.get(fileAbsPath)!.has(stat.mtimeMs)) {
-    return memo.get(fileAbsPath)!.get(stat.mtimeMs)!;
+
+  let memoForFile = memo.get(fileAbsPath);
+  if (!memoForFile) {
+    memoForFile = new Map<number, string>();
+    memo.set(fileAbsPath, memoForFile);
   }
-  const hash = await computeHash(fileAbsPath);
-  if (!memo.has(fileAbsPath)) {
-    memo.set(fileAbsPath, new Map<number, string>());
+
+  let hash = memoForFile.get(stat.mtimeMs);
+  if (!hash) {
+    hash = await computeHash(fileAbsPath);
+    memoForFile.set(stat.mtimeMs, hash);
   }
-  memo.get(fileAbsPath)!.set(stat.mtimeMs, hash);
   return hash;
 }


### PR DESCRIPTION
`yarn lint` should be running as part of the CI build to prevent errors from being checked in (since pre-commit checks can be skipped).

I also simplified some logic in `backfill-cache` to remove lint warnings.