### PR TITLE
Update monorepo package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "backfill-repo",
+  "name": "@microsoft/backfill-repo",
   "version": "2.0.0",
   "license": "MIT",
   "repository": {
@@ -75,7 +75,7 @@
           "execa"
         ],
         "packages": [
-          "backfill-repo"
+          "@microsoft/backfill-repo"
         ]
       }
     ]


### PR DESCRIPTION
Update the monorepo "package" name to use a Microsoft-owned scope. This "package" will never be published or installed, but the name change prevents spurious claims of dependency confusion vulnerabilities.