### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/change/change-ead3fc7b-8a2e-4d81-83cf-144143af9ad6.json
+++ b/change/change-ead3fc7b-8a2e-4d81-83cf-144143af9ad6.json
@@ -9,6 +9,13 @@
     },
     {
       "type": "patch",
+      "comment": "Remove unused dependency on fs-extra",
+      "packageName": "backfill-config",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
       "comment": "Remove unnecessary dependency on find-up",
       "packageName": "backfill-hasher",
       "email": "elcraig@microsoft.com",

--- a/change/change-ead3fc7b-8a2e-4d81-83cf-144143af9ad6.json
+++ b/change/change-ead3fc7b-8a2e-4d81-83cf-144143af9ad6.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Remove unused dependencies",
+      "packageName": "backfill-cache",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Remove unnecessary dependency on find-up",
+      "packageName": "backfill-hasher",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -17,11 +17,9 @@
   },
   "dependencies": {
     "@azure/storage-blob": "^12.15.0",
-    "@rushstack/package-deps-hash": "^3.2.4",
     "backfill-config": "^6.4.0",
     "backfill-logger": "^5.2.0",
     "execa": "^5.0.0",
-    "find-up": "^5.0.0",
     "fs-extra": "^8.1.0",
     "globby": "^11.0.0",
     "p-limit": "^3.0.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "backfill-logger": "^5.2.0",
     "find-up": "^5.0.0",
-    "fs-extra": "^8.1.0",
     "pkg-dir": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -19,9 +19,8 @@
     "@rushstack/package-deps-hash": "^3.2.4",
     "backfill-config": "^6.4.0",
     "backfill-logger": "^5.2.0",
-    "find-up": "^5.0.0",
     "fs-extra": "^8.1.0",
-    "workspace-tools": "^0.35.0"
+    "workspace-tools": "^0.35.2"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",

--- a/packages/hasher/src/helpers.ts
+++ b/packages/hasher/src/helpers.ts
@@ -1,6 +1,5 @@
-import path from "path";
 import crypto from "crypto";
-import findUp from "find-up";
+import { findPackageRoot } from "workspace-tools";
 
 export function hashStrings(strings: string | string[]): string {
   const hasher = crypto.createHash("sha1");
@@ -14,13 +13,13 @@ export function hashStrings(strings: string | string[]): string {
 }
 
 export async function getPackageRoot(cwd: string): Promise<string> {
-  const packageRoot = await findUp("package.json", { cwd });
+  const packageRoot = findPackageRoot(cwd);
 
   if (!packageRoot) {
     throw new Error(`Could not find package.json inside ${cwd}.`);
   }
 
-  return path.dirname(packageRoot);
+  return packageRoot;
 }
 
 export function nameAtVersion(name: string, version: string): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6963,6 +6963,19 @@ workspace-tools@^0.35.0:
     js-yaml "^4.1.0"
     micromatch "^4.0.0"
 
+workspace-tools@^0.35.2:
+  version "0.35.2"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.35.2.tgz#a89206d76a5fd2d1197b6c463ab2f507d39215ff"
+  integrity sha512-x637etwRdY3kbiSAJzAUbja4gzL/kMbDy8WX8yGK+ZvRlMY3o+G3UzvdEjwipVZ7C+RIUVdk/QV/hoRzbUcKiQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    fast-glob "^3.3.1"
+    git-url-parse "^13.0.0"
+    globby "^11.0.0"
+    jju "^1.4.0"
+    js-yaml "^4.1.0"
+    micromatch "^4.0.0"
+
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"


### PR DESCRIPTION
`backfill-cache` had unused dependencies on `@rushstack/package-deps-hash` and `find-up`.

`backfill-cache` had an unused dependency on `fs-extra`.

`backfill-hasher` had an unnecessary dependency on `find-up`, where `workspace-tools` (which it also depends on) can be used instead.