### PR TITLE
Add option to pass ContainerClient instead of connection string, container, and credentials to AzureBlobCacheStorage

### DIFF
--- a/change/change-2416297f-f036-427e-bc7e-7693f953608c.json
+++ b/change/change-2416297f-f036-427e-bc7e-7693f953608c.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Pass ContainerClient instead of connection string, container and credentials",
+      "packageName": "backfill-cache",
+      "email": "altinokd@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Pass ContainerClient instead of connection string, container and credentials",
+      "packageName": "backfill-config",
+      "email": "altinokd@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-2416297f-f036-427e-bc7e-7693f953608c.json
+++ b/change/change-2416297f-f036-427e-bc7e-7693f953608c.json
@@ -2,14 +2,14 @@
   "changes": [
     {
       "type": "patch",
-      "comment": "Pass ContainerClient instead of connection string, container and credentials",
+      "comment": "Adding an option to pass ContainerClient instead of connection string, container and credentials to AzureBlobCacheStorage",
       "packageName": "backfill-cache",
       "email": "altinokd@microsoft.com",
       "dependentChangeType": "patch"
     },
     {
       "type": "patch",
-      "comment": "Pass ContainerClient instead of connection string, container and credentials",
+      "comment": "Adding an option to pass ContainerClient instead of connection string, container and credentials to AzureBlobCacheStorage",
       "packageName": "backfill-config",
       "email": "altinokd@microsoft.com",
       "dependentChangeType": "patch"

--- a/change/change-2416297f-f036-427e-bc7e-7693f953608c.json
+++ b/change/change-2416297f-f036-427e-bc7e-7693f953608c.json
@@ -1,14 +1,14 @@
 {
   "changes": [
     {
-      "type": "patch",
+      "type": "minor",
       "comment": "Adding an option to pass ContainerClient instead of connection string, container and credentials to AzureBlobCacheStorage",
       "packageName": "backfill-cache",
       "email": "altinokd@microsoft.com",
       "dependentChangeType": "patch"
     },
     {
-      "type": "patch",
+      "type": "minor",
       "comment": "Adding an option to pass ContainerClient instead of connection string, container and credentials to AzureBlobCacheStorage",
       "packageName": "backfill-config",
       "email": "altinokd@microsoft.com",

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -70,7 +70,7 @@ const uploadOptions = {
 };
 
 export class AzureBlobCacheStorage extends CacheStorage {
-  private readonly getConatinerClient: () => Promise<ContainerClient>;
+  private readonly getContainerClient: () => Promise<ContainerClient>;
 
   constructor(
     private options: AzureBlobCacheStorageOptions,
@@ -81,11 +81,11 @@ export class AzureBlobCacheStorage extends CacheStorage {
     super(logger, cwd, incrementalCaching);
 
     if ("containerClient" in options) {
-      this.getConatinerClient = () => Promise.resolve(options.containerClient);
+      this.getContainerClient = () => Promise.resolve(options.containerClient);
     } else {
       const { connectionString, container, credential } = options;
       // This is delay loaded because it's very slow to parse
-      this.getConatinerClient = () =>
+      this.getContainerClient = () =>
         import("@azure/storage-blob").then(({ BlobServiceClient }) => {
           const blobServiceClient = credential
             ? new BlobServiceClient(connectionString, credential)
@@ -100,7 +100,7 @@ export class AzureBlobCacheStorage extends CacheStorage {
 
   protected async _fetch(hash: string): Promise<boolean> {
     try {
-      const blobClient = (await this.getConatinerClient()).getBlobClient(hash);
+      const blobClient = (await this.getContainerClient()).getBlobClient(hash);
 
       // If a maxSize has been specified, make sure to check the properties for the size before transferring
       if (this.options.maxSize) {
@@ -162,7 +162,7 @@ export class AzureBlobCacheStorage extends CacheStorage {
   }
 
   protected async _put(hash: string, filesToCache: string[]): Promise<void> {
-    const blobClient = (await this.getConatinerClient()).getBlobClient(hash);
+    const blobClient = (await this.getContainerClient()).getBlobClient(hash);
 
     const blockBlobClient = blobClient.getBlockBlobClient();
 

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -6,7 +6,7 @@ import { Logger } from "backfill-logger";
 import { AzureBlobCacheStorageOptions } from "backfill-config";
 
 import { stat } from "fs-extra";
-import { TokenCredential } from "@azure/core-http";
+import { ContainerClient } from "@azure/storage-blob";
 import { CacheStorage } from "./CacheStorage";
 
 const ONE_MEGABYTE = 1024 * 1024;
@@ -69,25 +69,9 @@ const uploadOptions = {
   maxBuffers: 5,
 };
 
-async function createBlobClient(
-  connectionString: string,
-  containerName: string,
-  blobName: string,
-  credential: TokenCredential | undefined
-) {
-  // This is delay loaded because it's very slow to parse
-  const { BlobServiceClient } = await import("@azure/storage-blob");
-  const blobServiceClient = credential
-    ? new BlobServiceClient(connectionString, credential)
-    : BlobServiceClient.fromConnectionString(connectionString);
-
-  const containerClient = blobServiceClient.getContainerClient(containerName);
-  const blobClient = containerClient.getBlobClient(blobName);
-
-  return blobClient;
-}
-
 export class AzureBlobCacheStorage extends CacheStorage {
+  private readonly conatinerClient: Promise<ContainerClient>;
+
   constructor(
     private options: AzureBlobCacheStorageOptions,
     logger: Logger,
@@ -95,16 +79,29 @@ export class AzureBlobCacheStorage extends CacheStorage {
     incrementalCaching = false
   ) {
     super(logger, cwd, incrementalCaching);
+
+    if ("containerClient" in options) {
+      this.conatinerClient = Promise.resolve(options.containerClient);
+    } else {
+      // This is delay loaded because it's very slow to parse
+      this.conatinerClient = import("@azure/storage-blob").then(
+        ({ BlobServiceClient }) => {
+          const { connectionString, container, credential } = options;
+          const blobServiceClient = credential
+            ? new BlobServiceClient(connectionString, credential)
+            : BlobServiceClient.fromConnectionString(connectionString);
+
+          const containerClient =
+            blobServiceClient.getContainerClient(container);
+          return containerClient;
+        }
+      );
+    }
   }
 
   protected async _fetch(hash: string): Promise<boolean> {
     try {
-      const blobClient = await createBlobClient(
-        this.options.connectionString,
-        this.options.container,
-        hash,
-        this.options.credential
-      );
+      const blobClient = (await this.conatinerClient).getBlobClient(hash);
 
       // If a maxSize has been specified, make sure to check the properties for the size before transferring
       if (this.options.maxSize) {
@@ -166,12 +163,7 @@ export class AzureBlobCacheStorage extends CacheStorage {
   }
 
   protected async _put(hash: string, filesToCache: string[]): Promise<void> {
-    const blobClient = await createBlobClient(
-      this.options.connectionString,
-      this.options.container,
-      hash,
-      this.options.credential
-    );
+    const blobClient = (await this.conatinerClient).getBlobClient(hash);
 
     const blockBlobClient = blobClient.getBlockBlobClient();
 

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -70,7 +70,7 @@ const uploadOptions = {
 };
 
 export class AzureBlobCacheStorage extends CacheStorage {
-  private readonly conatinerClient: Promise<ContainerClient>;
+  private readonly getConatinerClient: () => Promise<ContainerClient>;
 
   constructor(
     private options: AzureBlobCacheStorageOptions,
@@ -81,12 +81,12 @@ export class AzureBlobCacheStorage extends CacheStorage {
     super(logger, cwd, incrementalCaching);
 
     if ("containerClient" in options) {
-      this.conatinerClient = Promise.resolve(options.containerClient);
+      this.getConatinerClient = () => Promise.resolve(options.containerClient);
     } else {
+      const { connectionString, container, credential } = options;
       // This is delay loaded because it's very slow to parse
-      this.conatinerClient = import("@azure/storage-blob").then(
-        ({ BlobServiceClient }) => {
-          const { connectionString, container, credential } = options;
+      this.getConatinerClient = () =>
+        import("@azure/storage-blob").then(({ BlobServiceClient }) => {
           const blobServiceClient = credential
             ? new BlobServiceClient(connectionString, credential)
             : BlobServiceClient.fromConnectionString(connectionString);
@@ -94,14 +94,13 @@ export class AzureBlobCacheStorage extends CacheStorage {
           const containerClient =
             blobServiceClient.getContainerClient(container);
           return containerClient;
-        }
-      );
+        });
     }
   }
 
   protected async _fetch(hash: string): Promise<boolean> {
     try {
-      const blobClient = (await this.conatinerClient).getBlobClient(hash);
+      const blobClient = (await this.getConatinerClient()).getBlobClient(hash);
 
       // If a maxSize has been specified, make sure to check the properties for the size before transferring
       if (this.options.maxSize) {
@@ -163,7 +162,7 @@ export class AzureBlobCacheStorage extends CacheStorage {
   }
 
   protected async _put(hash: string, filesToCache: string[]): Promise<void> {
-    const blobClient = (await this.conatinerClient).getBlobClient(hash);
+    const blobClient = (await this.getConatinerClient()).getBlobClient(hash);
 
     const blockBlobClient = blobClient.getBlockBlobClient();
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@azure/core-http": "^3.0.0",
+    "@azure/storage-blob": "^12.15.0",
     "backfill-logger": "^5.2.1",
     "find-up": "^5.0.0",
     "pkg-dir": "^4.2.0"

--- a/packages/config/src/cacheConfig.ts
+++ b/packages/config/src/cacheConfig.ts
@@ -1,4 +1,5 @@
 import { TokenCredential } from "@azure/core-http";
+import { ContainerClient } from "@azure/storage-blob";
 import { Logger } from "backfill-logger";
 
 export interface ICacheStorage {
@@ -6,12 +7,17 @@ export interface ICacheStorage {
   put: (hash: string, filesToCache: string[]) => Promise<void>;
 }
 
-export type AzureBlobCacheStorageOptions = {
-  connectionString: string;
-  container: string;
-  maxSize?: number;
-  credential?: TokenCredential;
-};
+export type AzureBlobCacheStorageOptions =
+  | {
+      connectionString: string;
+      container: string;
+      maxSize?: number;
+      credential?: TokenCredential;
+    }
+  | {
+      containerClient: ContainerClient;
+      maxSize?: number;
+    };
 
 export type NpmCacheStorageOptions = {
   npmPackageName: string;


### PR DESCRIPTION
This pull request includes changes to the `backfill-cache` and `backfill-config` packages to add an option for passing a `ContainerClient` instead of connection string, container, and credentials to `AzureBlobCacheStorage`. The most important changes include updating the `AzureBlobCacheStorage` class and modifying the configuration options.

Changes to `AzureBlobCacheStorage`:

* [`packages/cache/src/AzureBlobCacheStorage.ts`](diffhunk://#diff-47051dbfbdcff4195fc605559c9bad2995810f32be3f59fc5deef1e59bd72ff9L9-R9): Added a new method to get the `ContainerClient` either from the options or by creating it using the connection string, container, and credentials. Removed the `createBlobClient` function and updated the `_fetch` and `_put` methods to use the new `getContainerClient` method. [[1]](diffhunk://#diff-47051dbfbdcff4195fc605559c9bad2995810f32be3f59fc5deef1e59bd72ff9L9-R9) [[2]](diffhunk://#diff-47051dbfbdcff4195fc605559c9bad2995810f32be3f59fc5deef1e59bd72ff9L72-R103) [[3]](diffhunk://#diff-47051dbfbdcff4195fc605559c9bad2995810f32be3f59fc5deef1e59bd72ff9L169-R165)

Configuration updates:

* [`packages/config/src/cacheConfig.ts`](diffhunk://#diff-4dbb9f15249d87a8f07baef1fdbef4a6a233b25f788288391ae554ae3ed877e3R2-R19): Modified the `AzureBlobCacheStorageOptions` type to include an option for passing a `ContainerClient`.
* [`packages/config/package.json`](diffhunk://#diff-fd956f6d78d80e1989716c00afb66f1ac64847e9b4a3673def6f483cd218e963R20): Added `@azure/storage-blob` as a dependency.

Documentation updates:

* [`change/change-2416297f-f036-427e-bc7e-7693f953608c.json`](diffhunk://#diff-360863f6cf6f57e0517940d1fee0d5e104ba5f3e71cc39b5a0b712ee27aa2a31R1-R18): Added entries to document the changes in both `backfill-cache` and `backfill-config` packages.