### PR TITLE
Remove direct reference to `@azure/storage-blob` in config types

### DIFF
--- a/change/change-e8d7a09c-98ee-47ce-86c9-11df81f9d02b.json
+++ b/change/change-e8d7a09c-98ee-47ce-86c9-11df81f9d02b.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "Update type usage",
+      "packageName": "backfill-cache",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "patch",
+      "comment": "Remove direct reference to `@azure/storage-blob` in types (use a minimal facade type for `AzureBlobCacheStorageOptions.containerClient`)",
+      "packageName": "backfill-config",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cache/src/AzureBlobCacheStorage.ts
+++ b/packages/cache/src/AzureBlobCacheStorage.ts
@@ -81,7 +81,8 @@ export class AzureBlobCacheStorage extends CacheStorage {
     super(logger, cwd, incrementalCaching);
 
     if ("containerClient" in options) {
-      this.getContainerClient = () => Promise.resolve(options.containerClient);
+      this.getContainerClient = () =>
+        Promise.resolve(options.containerClient as ContainerClient);
     } else {
       const { connectionString, container, credential } = options;
       // This is delay loaded because it's very slow to parse

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@azure/core-http": "^3.0.0",
-    "@azure/storage-blob": "^12.15.0",
     "backfill-logger": "^5.3.0",
     "find-up": "^5.0.0",
     "pkg-dir": "^4.2.0"

--- a/packages/config/src/cacheConfig.ts
+++ b/packages/config/src/cacheConfig.ts
@@ -1,5 +1,4 @@
 import { TokenCredential } from "@azure/core-http";
-import { ContainerClient } from "@azure/storage-blob";
 import { Logger } from "backfill-logger";
 
 export interface ICacheStorage {
@@ -15,7 +14,13 @@ export type AzureBlobCacheStorageOptions =
       credential?: TokenCredential;
     }
   | {
-      containerClient: ContainerClient;
+      /**
+       * `ContainerClient` from `@azure/storage-blob`.
+       * (This prevents pulling in a large tree of types for the config, especially in `lage`'s types rollup.)
+       */
+      containerClient: {
+        getBlobClient: (hash: string) => unknown;
+      };
       maxSize?: number;
     };
 


### PR DESCRIPTION
Having a direct reference to the `ContainerClient` type from `@azure/storage-blob` creates extra headaches with the rollup of `lage` config types, by pulling in a giant and regularly-growing tree of types from `@azure/*` packages.

Replace the direct reference with a basic object type with a stub of the one method used.